### PR TITLE
improve error check

### DIFF
--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -163,7 +163,7 @@ func (actionHandler *ActionHandler) parseRegistryNameArg(sessionObj *utils.Sessi
 func (actionHandler *ActionHandler) testRegistryConnect(registry *registryScan, sessionObj *utils.SessionObj) error {
 	repos, err := registry.enumerateRepoes()
 	if err != nil {
-		if strings.Contains(strings.ToLower(err.Error()), "unauthorized") || strings.Contains(strings.ToLower(err.Error()), "DENIED") || strings.Contains(strings.ToLower(err.Error()), "authentication") {
+		if strings.Contains(strings.ToLower(err.Error()), "unauthorized") || strings.Contains(strings.ToLower(err.Error()), "DENIED") || strings.Contains(strings.ToLower(err.Error()), "authentication") || strings.Contains(strings.ToLower(err.Error()), "empty token") {
 			// registry info is good, but authentication failed
 			sessionObj.Reporter.SetDetails(string(testRegistryInformationStatus))
 			sessionObj.Reporter.SendStatus(reporterlib.JobSuccess, true, sessionObj.ErrChan)


### PR DESCRIPTION
quay.io returns "empty token" for bad auth