### PR TITLE
rm tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/operator
 go 1.18
 
 require (
-	github.com/armosec/armoapi-go v0.0.129
+	github.com/armosec/armoapi-go v0.0.136
 	github.com/armosec/cluster-notifier-api-go v0.0.3
 	github.com/armosec/logger-go v0.0.13
 	github.com/armosec/opa-utils v0.0.166

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/armosec/armoapi-go v0.0.129 h1:Czs75brSh8N9l6bVAOro2wLIqS00N8UFvKsG84KUMyU=
-github.com/armosec/armoapi-go v0.0.129/go.mod h1:2zoNzb3Fy9ZByeczJZ47ftDRLRzTykVdTISS3GTc/JU=
+github.com/armosec/armoapi-go v0.0.136 h1:ykXJD4+CGkgMIwsxUrNam2qoRoVMKeBEuHhmAMCotMk=
+github.com/armosec/armoapi-go v0.0.136/go.mod h1:2zoNzb3Fy9ZByeczJZ47ftDRLRzTykVdTISS3GTc/JU=
 github.com/armosec/cluster-notifier-api-go v0.0.3 h1:noJ6IL/Bnkn2hnNLFvMwIMaZsxY9DJ+3MEQi3i/DAQI=
 github.com/armosec/cluster-notifier-api-go v0.0.3/go.mod h1:7J+XboqvPNAPABtkH2ecITg8/23fP4YXvtAa5wJONQU=
 github.com/armosec/gojay v1.2.15 h1:sSB2vnAvacUNkw9nzUYZKcPzhJOyk6/5LK2JCNdmoZY=

--- a/mainhandler/imageregistryhandler.go
+++ b/mainhandler/imageregistryhandler.go
@@ -76,10 +76,10 @@ type registryScan struct {
 }
 
 type RepositoriesAndTagsParams struct {
-	RepositoriesAndTags map[string][]string `json:"repositoriesAndTags"`
-	CustomerGUID        string              `json:"customerGUID"`
-	RegistryName        string              `json:"registryName"`
-	JobID               string              `json:"jobID"`
+	Repositories []armotypes.Repository `json:"repositories"`
+	CustomerGUID string                 `json:"customerGUID"`
+	RegistryName string                 `json:"registryName"`
+	JobID        string                 `json:"jobID"`
 }
 
 type registryCreds struct {
@@ -720,7 +720,7 @@ func (registryScan *registryScan) setHostnameAndProject() {
 }
 
 func (registryScan *registryScan) SendRepositoriesAndTags(params RepositoriesAndTagsParams) error {
-	reqBody, err := json.Marshal(params.RepositoriesAndTags)
+	reqBody, err := json.Marshal(params.Repositories)
 	if err != nil {
 		return fmt.Errorf("in 'sendReport' failed to json.Marshal, reason: %v", err)
 	}
@@ -738,7 +738,7 @@ func (registryScan *registryScan) SendRepositoriesAndTags(params RepositoriesAnd
 	urlQuery := url.URL{
 		Scheme: scheme,
 		Host:   eventReceiverRestURL,
-		Path:   "k8s/repositoriesToTags",
+		Path:   "k8s/registryRepositories",
 	}
 	query := url.Values{
 		"jobID":        []string{params.JobID},

--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -188,8 +188,9 @@ func (actionHandler *ActionHandler) testRegistryConnect(registry *registryScan, 
 	sessionObj.Reporter.SetDetails(string(testRegistryRetrieveReposStatus))
 	sessionObj.Reporter.SendStatus(reporterlib.JobSuccess, true, sessionObj.ErrChan)
 
-	for _, repo := range repos {
-		if err := registry.setImageToTagsMap(repo, sessionObj.Reporter); err != nil {
+	// check that we can pull tags. One is enough
+	if len(repos) > 0 {
+		if err := registry.setImageToTagsMap(repos[0], sessionObj.Reporter); err != nil {
 			sessionObj.Reporter.SetDetails(string(testRegistryRetrieveTagsStatus))
 			return fmt.Errorf("setImageToTagsMap failed with err %v", err)
 		}
@@ -198,11 +199,18 @@ func (actionHandler *ActionHandler) testRegistryConnect(registry *registryScan, 
 	sessionObj.Reporter.SetDetails(string(testRegistryRetrieveTagsStatus))
 	sessionObj.Reporter.SendStatus(reporterlib.JobSuccess, true, sessionObj.ErrChan)
 
+	var repositories []armotypes.Repository
+	for _, repo := range repos {
+		repositories = append(repositories, armotypes.Repository{
+			RepositoryName: repo,
+		})
+	}
+
 	params := RepositoriesAndTagsParams{
-		RegistryName:        registry.registryInfo.RegistryName,
-		CustomerGUID:        sessionObj.Reporter.GetCustomerGUID(),
-		JobID:               sessionObj.Reporter.GetJobID(),
-		RepositoriesAndTags: registry.mapImageToTags,
+		RegistryName: registry.registryInfo.RegistryName,
+		CustomerGUID: sessionObj.Reporter.GetCustomerGUID(),
+		JobID:        sessionObj.Reporter.GetJobID(),
+		Repositories: repositories,
 	}
 
 	err = registry.SendRepositoriesAndTags(params)


### PR DESCRIPTION
1 - Send only repositories to event receiver, and not tags

2 - Don't retrieve all tags, only one (to check that we have the permissions)

3 - Update event receiver API