### PR TITLE
use RegistryProvider when set to choose registry kind

### DIFF
--- a/mainhandler/imageregistryhandler.go
+++ b/mainhandler/imageregistryhandler.go
@@ -607,7 +607,6 @@ func (registryScan *registryScan) setRegistryKind() {
 
 func (registryScan *registryScan) getRegistryProvider() string {
 	if strings.Contains(registryScan.registryInfo.RegistryName, ".dkr.ecr") {
-
 		return "ecr"
 	}
 	if strings.Contains(registryScan.registryInfo.RegistryName, "gcr.io") {
@@ -616,7 +615,7 @@ func (registryScan *registryScan) getRegistryProvider() string {
 	if strings.Contains(registryScan.registryInfo.RegistryName, "quay.io") {
 		return "quay.io"
 	}
-	return ""
+	return registryScan.registryInfo.RegistryProvider
 }
 
 // parse registry information from secret, configmap and command, giving priority to command


### PR DESCRIPTION
## Overview
Fixes SUB-689 when a user tries to add registry scanning for a Harbor registry.
This probably failed for other registries where the URL didn't allow proper type detection.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 