### PR TITLE
feat: add a handler for Filtered SBOMs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/deckarep/golang-set/v2 v2.3.0 // indirect
 	github.com/docker/cli v20.10.17+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.3.0 h1:qs18EKUfHm2X9fA50Mr/M5hccg2tNnVqsiBImnyDs0g=
+github.com/deckarep/golang-set/v2 v2.3.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=

--- a/watcher/errors.go
+++ b/watcher/errors.go
@@ -1,0 +1,12 @@
+package watcher
+
+import (
+	"errors"
+)
+
+var (
+	ErrUnsupportedEvent     = errors.New("Received an unsupported event type for processing")
+	ErrUnsupportedObject    = errors.New("Unsupported object type")
+	ErrUnknownImageID       = errors.New("Unknown image ID")
+	ErrMissingWorkloadLabel = errors.New("Missing a necessary workload label")
+)

--- a/watcher/maps.go
+++ b/watcher/maps.go
@@ -2,11 +2,19 @@ package watcher
 
 import (
 	"sync"
+
+	sets "github.com/deckarep/golang-set/v2"
 )
+
+type wlidSet sets.Set[string]
+
+func NewWLIDSet(values ...string) wlidSet {
+	return sets.NewSet(values...)
+}
 
 // imageIDWLIDMap maps an Image ID to a list of WLIDs that are running it
 type imageIDWLIDMap struct {
-	wlidsByImageID map[string][]string
+	wlidsByImageID map[string]wlidSet
 	mu             sync.RWMutex
 }
 
@@ -18,11 +26,11 @@ func NewImageIDWLIDsMap() *imageIDWLIDMap {
 func (m *imageIDWLIDMap) init() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.wlidsByImageID = make(map[string][]string)
+	m.wlidsByImageID = make(map[string]wlidSet)
 }
 
 // Set sets a given list of WLIDs for the provided image ID
-func (m *imageIDWLIDMap) Set(imageID string, wlids []string) {
+func (m *imageIDWLIDMap) Set(imageID string, wlids wlidSet) {
 	if m.wlidsByImageID == nil {
 		m.init()
 	}
@@ -32,16 +40,19 @@ func (m *imageIDWLIDMap) Set(imageID string, wlids []string) {
 }
 
 // Get returns a list of WLIDs for the provided imageID
-func (m *imageIDWLIDMap) Get(imageID string) ([]string, bool) {
+func (m *imageIDWLIDMap) Get(imageID string) (wlidSet, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	val, ok := m.wlidsByImageID[imageID]
-	return val, ok
+	if !ok {
+		return val, ok
+	}
+	return val.Clone(), ok
 }
 
 // Clear clears the map and sets it to an empty map
 func (m *imageIDWLIDMap) Clear() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.wlidsByImageID = map[string][]string{}
+	m.wlidsByImageID = map[string]wlidSet{}
 }

--- a/watcher/maps.go
+++ b/watcher/maps.go
@@ -1,0 +1,47 @@
+package watcher
+
+import (
+	"sync"
+)
+
+// imageIDWLIDMap maps an Image ID to a list of WLIDs that are running it
+type imageIDWLIDMap struct {
+	wlidsByImageID map[string][]string
+	mu             sync.RWMutex
+}
+
+// NewImageIDWLIDsMap returns a new ImageID to WLID map
+func NewImageIDWLIDsMap() *imageIDWLIDMap {
+	return &imageIDWLIDMap{}
+}
+
+func (m *imageIDWLIDMap) init() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.wlidsByImageID = make(map[string][]string)
+}
+
+// Set sets a given list of WLIDs for the provided image ID
+func (m *imageIDWLIDMap) Set(imageID string, wlids []string) {
+	if m.wlidsByImageID == nil {
+		m.init()
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.wlidsByImageID[imageID] = wlids
+}
+
+// Get returns a list of WLIDs for the provided imageID
+func (m *imageIDWLIDMap) Get(imageID string) ([]string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	val, ok := m.wlidsByImageID[imageID]
+	return val, ok
+}
+
+// Clear clears the map and sets it to an empty map
+func (m *imageIDWLIDMap) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.wlidsByImageID = map[string][]string{}
+}

--- a/watcher/maps_test.go
+++ b/watcher/maps_test.go
@@ -1,0 +1,159 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageIDWLIDsMapNew(t *testing.T) {
+	var iwMap *imageIDWLIDMap
+	iwMap = NewImageIDWLIDsMap()
+
+	assert.NotNilf(t, iwMap, "Returned map should not be nil")
+}
+
+func TestImageIDWLIDsMapSetAndGet(t *testing.T) {
+	tt := []struct {
+		name        string
+		inputKVs    map[string][]string
+		expectedKVs map[string][]string
+		expectedOks map[string]bool
+	}{
+		{
+			name: "Storing a single value should return a matching value",
+			inputKVs: map[string][]string{
+				"someImageID": {"someWLID"},
+			},
+			expectedKVs: map[string][]string{
+				"someImageID": {"someWLID"},
+			},
+			expectedOks: map[string]bool{
+				"someImageID": true,
+			},
+		},
+		{
+			name: "Storing multiple keys should return matching values",
+			inputKVs: map[string][]string{
+				"someImageID":      {"someWLID"},
+				"someOtherImageID": {"someOtherWLID"},
+			},
+			expectedKVs: map[string][]string{
+				"someImageID":      {"someWLID"},
+				"someOtherImageID": {"someOtherWLID"},
+			},
+			expectedOks: map[string]bool{
+				"someImageID":      true,
+				"someOtherImageID": true,
+			},
+		},
+		{
+			name:     "Getting from empty map should return a NOT ok flag",
+			inputKVs: map[string][]string{},
+			expectedKVs: map[string][]string{
+				"someImageID": nil,
+			},
+			expectedOks: map[string]bool{
+				"someImageID": false,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMap()
+
+			for k, v := range tc.inputKVs {
+				iwMap.Set(k, v)
+			}
+
+			actualKVs := map[string][]string{}
+			for k := range tc.expectedKVs {
+				actualValue, _ := iwMap.Get(k)
+				actualKVs[k] = actualValue
+			}
+
+			actualOks := map[string]bool{}
+			for k := range tc.expectedOks {
+				_, ok := iwMap.Get(k)
+				actualOks[k] = ok
+			}
+
+			assert.Equalf(t, tc.expectedKVs, actualKVs, "Stored value must match the input value")
+			assert.Equalf(t, tc.expectedOks, actualOks, "Actual OKs must match the expected OKs")
+		})
+	}
+}
+
+func TestImageIDWLIDsMapGetResultImmutable(t *testing.T) {
+	tt := []struct {
+		name        string
+		startingMap map[string][]string
+		appendInput []string
+		testKey     string
+		expected    []string
+	}{
+		{
+			name: "Plain appending to Get result of a map should not mutate the underlying map",
+			startingMap: map[string][]string{
+				"some": {"first", "second"},
+			},
+			testKey:     "some",
+			appendInput: []string{"INTRUDER"},
+			expected:    []string{"first", "second"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMap()
+			for k, v := range tc.startingMap {
+				iwMap.Set(k, v)
+			}
+			got, _ := iwMap.Get(tc.testKey)
+
+			for _, input := range tc.appendInput {
+				got = append(got, input)
+			}
+
+			actual, _ := iwMap.Get(tc.testKey)
+
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestImageIDWLIDsMapClear(t *testing.T) {
+	tt := []struct {
+		name string
+		startingValues map[string][]string
+	}{
+		{
+			name: "Clearing a non-empty map should make it an empty map",
+			startingValues: map[string][]string{
+				"imageID": {"wlid01", "wlid02"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMap()
+			for k, v := range tc.startingValues {
+				iwMap.Set(k, v)
+			}
+
+			iwMap.Clear()
+
+			remainingValues := map[string][]string{}
+			for k := range tc.startingValues {
+				remainingValue, ok := iwMap.Get(k)
+				if ok {
+					remainingValues[k] = remainingValue
+				}
+			}
+			expectedRemainingValues := map[string][]string{}
+			assert.Equal(t, expectedRemainingValues, remainingValues)
+		})
+	}
+}

--- a/watcher/maps_test.go
+++ b/watcher/maps_test.go
@@ -3,8 +3,33 @@ package watcher
 import (
 	"testing"
 
+	sets "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestWLIDSetNew(t *testing.T) {
+	tt := []struct {
+		name        string
+		inputValues []string
+	}{
+		{
+			name:        "The created set should contain the input values",
+			inputValues: []string{"a", "b"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := NewWLIDSet(tc.inputValues...)
+
+			expectedValues := sets.NewSet(tc.inputValues...)
+			if !expectedValues.Equal(ws) {
+				t.Errorf("Given sets are not equal.")
+
+			}
+		})
+	}
+}
 
 func TestImageIDWLIDsMapNew(t *testing.T) {
 	var iwMap *imageIDWLIDMap
@@ -16,17 +41,17 @@ func TestImageIDWLIDsMapNew(t *testing.T) {
 func TestImageIDWLIDsMapSetAndGet(t *testing.T) {
 	tt := []struct {
 		name        string
-		inputKVs    map[string][]string
-		expectedKVs map[string][]string
+		inputKVs    map[string]wlidSet
+		expectedKVs map[string]wlidSet
 		expectedOks map[string]bool
 	}{
 		{
 			name: "Storing a single value should return a matching value",
-			inputKVs: map[string][]string{
-				"someImageID": {"someWLID"},
+			inputKVs: map[string]wlidSet{
+				"someImageID": NewWLIDSet("someWLID"),
 			},
-			expectedKVs: map[string][]string{
-				"someImageID": {"someWLID"},
+			expectedKVs: map[string]wlidSet{
+				"someImageID": NewWLIDSet("someWLID"),
 			},
 			expectedOks: map[string]bool{
 				"someImageID": true,
@@ -34,13 +59,13 @@ func TestImageIDWLIDsMapSetAndGet(t *testing.T) {
 		},
 		{
 			name: "Storing multiple keys should return matching values",
-			inputKVs: map[string][]string{
-				"someImageID":      {"someWLID"},
-				"someOtherImageID": {"someOtherWLID"},
+			inputKVs: map[string]wlidSet{
+				"someImageID":      NewWLIDSet("someWLID"),
+				"someOtherImageID": NewWLIDSet("someOtherWLID"),
 			},
-			expectedKVs: map[string][]string{
-				"someImageID":      {"someWLID"},
-				"someOtherImageID": {"someOtherWLID"},
+			expectedKVs: map[string]wlidSet{
+				"someImageID":      NewWLIDSet("someWLID"),
+				"someOtherImageID": NewWLIDSet("someOtherWLID"),
 			},
 			expectedOks: map[string]bool{
 				"someImageID":      true,
@@ -49,8 +74,8 @@ func TestImageIDWLIDsMapSetAndGet(t *testing.T) {
 		},
 		{
 			name:     "Getting from empty map should return a NOT ok flag",
-			inputKVs: map[string][]string{},
-			expectedKVs: map[string][]string{
+			inputKVs: map[string]wlidSet{},
+			expectedKVs: map[string]wlidSet{
 				"someImageID": nil,
 			},
 			expectedOks: map[string]bool{
@@ -67,7 +92,7 @@ func TestImageIDWLIDsMapSetAndGet(t *testing.T) {
 				iwMap.Set(k, v)
 			}
 
-			actualKVs := map[string][]string{}
+			actualKVs := map[string]wlidSet{}
 			for k := range tc.expectedKVs {
 				actualValue, _ := iwMap.Get(k)
 				actualKVs[k] = actualValue
@@ -88,19 +113,19 @@ func TestImageIDWLIDsMapSetAndGet(t *testing.T) {
 func TestImageIDWLIDsMapGetResultImmutable(t *testing.T) {
 	tt := []struct {
 		name        string
-		startingMap map[string][]string
+		startingMap map[string]wlidSet
 		appendInput []string
 		testKey     string
-		expected    []string
+		expected    wlidSet
 	}{
 		{
 			name: "Plain appending to Get result of a map should not mutate the underlying map",
-			startingMap: map[string][]string{
-				"some": {"first", "second"},
+			startingMap: map[string]wlidSet{
+				"some": NewWLIDSet("first", "second"),
 			},
 			testKey:     "some",
 			appendInput: []string{"INTRUDER"},
-			expected:    []string{"first", "second"},
+			expected:    NewWLIDSet("first", "second"),
 		},
 	}
 
@@ -113,25 +138,27 @@ func TestImageIDWLIDsMapGetResultImmutable(t *testing.T) {
 			got, _ := iwMap.Get(tc.testKey)
 
 			for _, input := range tc.appendInput {
-				got = append(got, input)
+				got.Add(input)
 			}
 
 			actual, _ := iwMap.Get(tc.testKey)
 
-			assert.Equal(t, tc.expected, actual)
+			if !actual.Equal(tc.expected) {
+				t.Errorf("Sets are not equal. Got: %v, want: %v", actual, tc.expected)
+			}
 		})
 	}
 }
 
 func TestImageIDWLIDsMapClear(t *testing.T) {
 	tt := []struct {
-		name string
-		startingValues map[string][]string
+		name           string
+		startingValues map[string]wlidSet
 	}{
 		{
 			name: "Clearing a non-empty map should make it an empty map",
-			startingValues: map[string][]string{
-				"imageID": {"wlid01", "wlid02"},
+			startingValues: map[string]wlidSet{
+				"imageID": NewWLIDSet("wlid01", "wlid02"),
 			},
 		},
 	}
@@ -145,15 +172,32 @@ func TestImageIDWLIDsMapClear(t *testing.T) {
 
 			iwMap.Clear()
 
-			remainingValues := map[string][]string{}
+			remainingValues := map[string]wlidSet{}
 			for k := range tc.startingValues {
 				remainingValue, ok := iwMap.Get(k)
 				if ok {
 					remainingValues[k] = remainingValue
 				}
 			}
-			expectedRemainingValues := map[string][]string{}
+			expectedRemainingValues := map[string]wlidSet{}
 			assert.Equal(t, expectedRemainingValues, remainingValues)
+		})
+	}
+}
+
+func TestImageIDWLIDsAdd(t *testing.T) {
+	tt := []struct {
+		name           string
+		startingValues map[string][]string
+	}{
+		{
+			name: "Adding an image ID to an empty map should be reflected",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.FailNow(t, "TODO")
 		})
 	}
 }

--- a/watcher/sbomfiltered.go
+++ b/watcher/sbomfiltered.go
@@ -1,0 +1,87 @@
+package watcher
+
+import (
+	"github.com/armosec/armoapi-go/apis"
+	pkgwlid "github.com/armosec/utils-k8s-go/wlid"
+	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+const (
+	workloadNamespaceLabel = "kubescape.io/workload-namespace"
+	workloadKindLabel      = "kubescape.io/workload-kind"
+	workloadNameLabel      = "kubescape.io/workload-name"
+)
+
+func labelsToNamespaceKindName(s *spdxv1beta1.SBOMSPDXv2p3Filtered) (string, string, string, error) {
+	labels := s.ObjectMeta.Labels
+
+	namespace, namespaceOk := labels[workloadNamespaceLabel]
+	kind, kindOk := labels[workloadKindLabel]
+	name, nameOk := labels[workloadNameLabel]
+	if !(namespaceOk && kindOk && nameOk) {
+		return namespace, kind, name, ErrMissingWorkloadLabel
+	}
+
+	return namespace, kind, name, nil
+}
+
+// ClusterNameResolvery is an interface for objects that can resolve the name
+// of a cluster we are currently running in
+type ClusterNameResolver interface {
+	// ResolveClusterName returns a name of a cluster we are currently running in
+	ResolveClusterName() string
+}
+
+// SBOMFilteredHandler handles operations that concern Filtered SBOMs
+type SBOMFilteredHandler struct {
+	clusterNameResolver ClusterNameResolver
+}
+
+// NewSBOMFilteredHandler returns a new instance of an SBOMFilteredHandler
+func NewSBOMFilteredHandler(cnr ClusterNameResolver) *SBOMFilteredHandler {
+	return &SBOMFilteredHandler{clusterNameResolver: cnr}
+}
+
+// HandleAddedEvent handles events about adding a new Filtered SBOM
+func (h *SBOMFilteredHandler) HandleAddedEvent(event watch.Event) (*apis.Command, error) {
+	if event.Type != watch.Added {
+		return nil, ErrUnsupportedEvent
+	}
+
+	clusterName := h.clusterNameResolver.ResolveClusterName()
+
+	sbomFiltered, ok := event.Object.(*spdxv1beta1.SBOMSPDXv2p3Filtered)
+	if !ok {
+		return nil, ErrUnsupportedObject
+	}
+	namespace, kind, name, err := labelsToNamespaceKindName(sbomFiltered)
+	if err != nil {
+		return nil, err
+	}
+
+	wlid := pkgwlid.GetWLID(clusterName, namespace, kind, name)
+
+	return getCVEScanCommand(wlid, map[string]string{}), nil
+}
+
+// HandleEvents continuously handles events about Filtered SBOMs
+func (h *SBOMFilteredHandler) HandleEvents(inputEvents <-chan watch.Event, producedCommands chan<- *apis.Command, producedErrors chan<- error) {
+	defer func() {
+		close(producedCommands)
+		close(producedErrors)
+	}()
+
+	for event := range inputEvents {
+		if event.Type != watch.Added {
+			continue
+		}
+
+		command, err := h.HandleAddedEvent(event)
+		if err != nil {
+			producedErrors <- err
+		} else {
+			producedCommands <- command
+		}
+	}
+}

--- a/watcher/sbomfiltered_test.go
+++ b/watcher/sbomfiltered_test.go
@@ -433,3 +433,18 @@ func TestSBOMFilteredHandlerHandleEvents(t *testing.T) {
 		})
 	}
 }
+
+func TestSBOMFilteredHandlerHandle(t *testing.T) {
+	tt := []struct {
+		name string
+	}{
+		{
+			name: "TODO",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+		})
+	}
+}

--- a/watcher/sbomfiltered_test.go
+++ b/watcher/sbomfiltered_test.go
@@ -1,0 +1,435 @@
+package watcher
+
+import (
+	"testing"
+
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/kubescape/operator/utils"
+	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type clusterNameResolverDummy struct {
+	returnedName string
+}
+
+func (c *clusterNameResolverDummy) ResolveClusterName() string {
+	return c.returnedName
+}
+
+func TestSBOMFilteredHandlerNew(t *testing.T) {
+	cnr := &clusterNameResolverDummy{}
+	sfh := NewSBOMFilteredHandler(cnr)
+
+	assert.NotNilf(t, sfh, "The returned handler should not be nil")
+	assert.Equalf(t, cnr, sfh.clusterNameResolver, "Cluster name resolvers should match")
+}
+
+func TestSBOMFilteredHandlerHandleAddedEvent(t *testing.T) {
+	tt := []struct {
+		name             string
+		inputClusterName string
+		inputEvent       watch.Event
+		expectedCommand  *apis.Command
+		expectedError    error
+	}{
+		{
+			name:             "Valid event produces matching command",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type: watch.Added,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"kubescape.io/workload-namespace": "routing",
+							"kubescape.io/workload-kind":      "deployment",
+							"kubescape.io/workload-name":      "nginx-main-router",
+						},
+					},
+				},
+			},
+			expectedCommand: &apis.Command{
+				Wlid:        "wlid://cluster-relevantCluster/namespace-routing/deployment-nginx-main-router",
+				CommandName: apis.TypeScanImages,
+				Args: map[string]interface{}{
+					utils.ContainerToImageIdsArg: map[string]string{},
+				},
+			},
+		},
+		{
+			name:             "Valid event produces matching command",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type: watch.Added,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"kubescape.io/workload-namespace": "routing",
+							"kubescape.io/workload-kind":      "Deployment",
+							"kubescape.io/workload-name":      "nginx-router-replica",
+						},
+					},
+				},
+			},
+			expectedCommand: &apis.Command{
+				Wlid:        "wlid://cluster-relevantCluster/namespace-routing/deployment-nginx-router-replica",
+				CommandName: apis.TypeScanImages,
+				Args: map[string]interface{}{
+					utils.ContainerToImageIdsArg: map[string]string{},
+				},
+			},
+		},
+		{
+			name:             "Missing workload namespace label produces an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type: watch.Added,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"kubescape.io/workload-kind": "Deployment",
+							"kubescape.io/workload-name": "nginx-router-replica",
+						},
+					},
+				},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrMissingWorkloadLabel,
+		},
+		{
+			name:             "Missing workload kind label produces an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type: watch.Added,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"kubescape.io/workload-namespace": "routing",
+							"kubescape.io/workload-name":      "nginx-router-replica",
+						},
+					},
+				},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrMissingWorkloadLabel,
+		},
+		{
+			name:             "Missing workload name label produces an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type: watch.Added,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							"kubescape.io/workload-namespace": "routing",
+							"kubescape.io/workload-kind":      "Deployment",
+						},
+					},
+				},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrMissingWorkloadLabel,
+		},
+		{
+			name:             "Unsupported object type in event produces an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type:   watch.Added,
+				Object: &spdxv1beta1.SBOMSPDXv2p3{},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrUnsupportedObject,
+		},
+		{
+			name:             "Attempts to process a Bookmark event returns an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type:   watch.Bookmark,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrUnsupportedEvent,
+		},
+		{
+			name:             "Attempts to process a Deleted event returns an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type:   watch.Deleted,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrUnsupportedEvent,
+		},
+		{
+			name:             "Attempts to process a Modified event returns an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type:   watch.Modified,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrUnsupportedEvent,
+		},
+		{
+			name:             "Attempts to process an Error event returns an appropriate error",
+			inputClusterName: "relevantCluster",
+			inputEvent: watch.Event{
+				Type:   watch.Error,
+				Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{},
+			},
+			expectedCommand: nil,
+			expectedError:   ErrUnsupportedEvent,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			clusterNameResolver := &clusterNameResolverDummy{tc.inputClusterName}
+			sfh := NewSBOMFilteredHandler(clusterNameResolver)
+
+			actualCommand, err := sfh.HandleAddedEvent(tc.inputEvent)
+
+			assert.Equalf(t, tc.expectedCommand, actualCommand, "Commands should match")
+			assert.Equalf(t, tc.expectedError, err, "Expected errors should match")
+		})
+	}
+}
+
+func TestSBOMFilteredHandlerHandleEvents(t *testing.T) {
+	tt := []struct {
+		name             string
+		inputClusterName string
+		inputEvents      []watch.Event
+		expectedCommands []apis.Command
+		expectedErrors   []error
+	}{
+		{
+			name:             "Added event gets an appropriate result",
+			inputClusterName: "relevancyCluster",
+			inputEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "testName",
+							Labels: map[string]string{
+								"kubescape.io/workload-namespace": "routing",
+								"kubescape.io/workload-kind":      "Deployment",
+								"kubescape.io/workload-name":      "edge-nginx",
+							},
+						},
+					},
+				},
+			},
+			expectedCommands: []apis.Command{
+				{
+					CommandName: apis.TypeScanImages,
+					Wlid:        "wlid://cluster-relevancyCluster/namespace-routing/deployment-edge-nginx",
+					Args: map[string]interface{}{
+						utils.ContainerToImageIdsArg: map[string]string{},
+					},
+				},
+			},
+			expectedErrors: []error{},
+		},
+		{
+			name: "Bookmark event gets ignored",
+			inputEvents: []watch.Event{
+				{
+					Type:   watch.Bookmark,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{},
+				},
+			},
+			expectedCommands: []apis.Command{},
+			expectedErrors:   []error{},
+		},
+		{
+			name: "Deleted event gets ignored",
+			inputEvents: []watch.Event{
+				{
+					Type:   watch.Deleted,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{},
+				},
+			},
+			expectedCommands: []apis.Command{},
+			expectedErrors:   []error{},
+		},
+		{
+			name:             "Added event gets an appropriate result",
+			inputClusterName: "relevancyCluster",
+			inputEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"kubescape.io/workload-namespace": "edge-routing",
+								"kubescape.io/workload-kind":      "Deployment",
+								"kubescape.io/workload-name":      "nginx-router",
+							},
+						},
+					},
+				},
+			},
+			expectedCommands: []apis.Command{
+				{
+					CommandName: apis.TypeScanImages,
+					Wlid:        "wlid://cluster-relevancyCluster/namespace-edge-routing/deployment-nginx-router",
+					Args: map[string]interface{}{
+						utils.ContainerToImageIdsArg: map[string]string{},
+					},
+				},
+			},
+			expectedErrors: []error{},
+		},
+		{
+			name: "Mismatched object gets an appropriate error",
+			inputEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{},
+					},
+				},
+			},
+			expectedCommands: []apis.Command{},
+			expectedErrors:   []error{ErrUnsupportedObject},
+		},
+		{
+			name:             "Skipped event does not disrupt listeners",
+			inputClusterName: "relevantCluster",
+			inputEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"kubescape.io/workload-namespace": "edge-routing",
+								"kubescape.io/workload-kind":      "Deployment",
+								"kubescape.io/workload-name":      "nginx-router",
+							},
+						},
+					},
+				},
+				{
+					Type: watch.Bookmark,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: metav1.ObjectMeta{},
+					},
+				},
+				{
+					Type: watch.Added,
+					Object: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{},
+					},
+				},
+			},
+			expectedCommands: []apis.Command{
+				{
+					CommandName: apis.TypeScanImages,
+					Wlid:        "wlid://cluster-relevantCluster/namespace-edge-routing/deployment-nginx-router",
+					Args: map[string]interface{}{
+						utils.ContainerToImageIdsArg: map[string]string{},
+					},
+				},
+			},
+			expectedErrors: []error{ErrUnsupportedObject},
+		},
+		{
+			name:             "Multiple added events produce matching commands",
+			inputClusterName: "relevantCluster",
+			inputEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"kubescape.io/workload-namespace": "edge-routing",
+								"kubescape.io/workload-kind":      "Deployment",
+								"kubescape.io/workload-name":      "nginx-router",
+							},
+						},
+					},
+				},
+				{
+					Type: watch.Added,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"kubescape.io/workload-namespace": "backbone",
+								"kubescape.io/workload-kind":      "StatefulSet",
+								"kubescape.io/workload-name":      "postgres-leader",
+							},
+						},
+					},
+				},
+			},
+			expectedCommands: []apis.Command{
+				{
+					CommandName: apis.TypeScanImages,
+					Wlid:        "wlid://cluster-relevantCluster/namespace-edge-routing/deployment-nginx-router",
+					Args: map[string]interface{}{
+						utils.ContainerToImageIdsArg: map[string]string{},
+					},
+				},
+				{
+					CommandName: apis.TypeScanImages,
+					Wlid:        "wlid://cluster-relevantCluster/namespace-backbone/statefulset-postgres-leader",
+					Args: map[string]interface{}{
+						utils.ContainerToImageIdsArg: map[string]string{},
+					},
+				},
+			},
+			expectedErrors: []error{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			cnr := &clusterNameResolverDummy{tc.inputClusterName}
+			sfh := NewSBOMFilteredHandler(cnr)
+
+			commandsCh := make(chan *apis.Command)
+			errCh := make(chan error)
+
+			sbomFilteredEvents := make(chan watch.Event)
+
+			go func() {
+				for _, event := range tc.inputEvents {
+					sbomFilteredEvents <- event
+				}
+
+				close(sbomFilteredEvents)
+			}()
+
+			go sfh.HandleEvents(sbomFilteredEvents, commandsCh, errCh)
+
+			actualCommands := []apis.Command{}
+			actualErrors := []error{}
+
+			var done bool
+			for !done {
+				select {
+				case command, ok := <-commandsCh:
+					if ok {
+						actualCommands = append(actualCommands, *command)
+					} else {
+						done = true
+					}
+				case err, ok := <-errCh:
+					if ok {
+						actualErrors = append(actualErrors, err)
+					} else {
+						done = true
+					}
+				}
+			}
+
+			assert.Equalf(t, tc.expectedCommands, actualCommands, "Commands should match")
+			assert.Equalf(t, tc.expectedErrors, actualErrors, "Errors should match")
+		})
+	}
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -3,7 +3,6 @@ package watcher
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -21,11 +20,6 @@ import (
 	core1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-)
-
-var (
-	ErrUnsupportedObject = errors.New("Unsupported object type")
-	ErrUnknownImageID    = errors.New("Unknown image ID")
 )
 
 type WlidsToContainerToImageIDMap map[string]map[string]string

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -418,7 +418,7 @@ func TestHandleSBOMEvents(t *testing.T) {
 func TestSBOMWatch(t *testing.T) {
 	t.Skipf(
 		"vladklokun: blocks and deadlocks while listening on the sbomWatcher.ResultChan(). " +
-		"Does not reproduce in a live cluster on a live Watch() object",
+			"Does not reproduce in a live cluster on a live Watch() object",
 	)
 
 	k8sClient := k8sfake.NewSimpleClientset()


### PR DESCRIPTION
## Overview
This PR adds a handler for Filtered SBOMs. This handler listens for events concerning Filtered SBOMs and processes them accordingly.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes