### PR TITLE
fix: Use image hash in WLID map

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/armosec/registryx v0.0.14
 	github.com/armosec/utils-go v0.0.14
 	github.com/armosec/utils-k8s-go v0.0.13
+	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/docker/docker v20.10.17+incompatible
 	github.com/go-openapi/runtime v0.24.1
 	github.com/google/go-containerregistry v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/deckarep/golang-set/v2 v2.3.0 h1:qs18EKUfHm2X9fA50Mr/M5hccg2tNnVqsiBImnyDs0g=
+github.com/deckarep/golang-set/v2 v2.3.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dnaeon/go-vcr v1.1.0 h1:ReYa/UBrRyQdant9B4fNHGoCNKw6qh6P0fsdGmZpR7c=

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -112,7 +112,7 @@ func (mainHandler *MainHandler) HandleWatchers(ctx context.Context) {
 	// get commands for scanning new images
 	commandsList := []*apis.Command{}
 	for _, imageID := range newImageIDs {
-		wlidsForImage := watchHandler.GetWlidsForImageID(imageID)
+		wlidsForImage := watchHandler.GetWlidsForImageHash(imageID)
 		if len(wlidsForImage) == 0 {
 			logger.L().Ctx(ctx).Error(fmt.Sprintf("Image %s is not used by any workload", imageID))
 			continue

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -92,7 +92,7 @@ func (mainHandler *MainHandler) HandleWatchers(ctx context.Context) {
 	if err != nil {
 		logger.L().Ctx(ctx).Fatal(fmt.Sprintf("Unable to initialize the storage client: %v", err))
 	}
-	watchHandler, err := watcher.NewWatchHandler(ctx, mainHandler.k8sAPI, ksStorageClient)
+	watchHandler, err := watcher.NewWatchHandler(ctx, mainHandler.k8sAPI, ksStorageClient, nil)
 
 	if err != nil {
 		logger.L().Ctx(ctx).Error(err.Error(), helpers.Error(err))

--- a/watcher/errors.go
+++ b/watcher/errors.go
@@ -1,0 +1,9 @@
+package watcher
+
+import (
+	"errors"
+)
+
+var (
+	errInvalidImageID = errors.New("input is not valid Image ID")
+)

--- a/watcher/maps.go
+++ b/watcher/maps.go
@@ -1,0 +1,147 @@
+package watcher
+
+import (
+	"sync"
+
+	sets "github.com/deckarep/golang-set/v2"
+)
+
+// wlidSet is a set of WLIDs.
+//
+// Uses a thread-safe implementation of sets.
+type wlidSet sets.Set[string]
+
+// NewWLIDSet returns a new empty set of WLIDs
+func NewWLIDSet(values ...string) wlidSet {
+	return sets.NewSet(values...)
+}
+
+// imageIDWLIDMap maps an Image ID to a list of WLIDs that are running it
+type imageIDWLIDMap struct {
+	wlidsByImageID map[string]wlidSet
+	mu             sync.RWMutex
+}
+
+// NewImageIDWLIDsMap returns a new ImageID to WLID map
+func NewImageIDWLIDsMap() *imageIDWLIDMap {
+	return &imageIDWLIDMap{}
+}
+
+// NewImageIDWLIDsMapFrom returns a new ImageID to WLID map populated from a map of starting values
+func NewImageIDWLIDsMapFrom(startingValues map[string][]string) *imageIDWLIDMap {
+	resultingMap := make(map[string]wlidSet)
+
+	for k, v := range startingValues {
+		resultingMap[k] = NewWLIDSet(v...)
+	}
+
+	return &imageIDWLIDMap{wlidsByImageID: resultingMap}
+}
+
+// init initializes the underlying map of WLIDs
+//
+// NOT THREAD-SAFE! Assumes that the caller is holding a Write lock.
+func (m *imageIDWLIDMap) init() {
+	m.wlidsByImageID = make(map[string]wlidSet)
+}
+
+// setUnsafe sets a given list of WLIDs for the provided image ID
+//
+// NOT THREAD SAFE! Assumes that the caller is holding a Write lock.
+func (m *imageIDWLIDMap) setUnsafe(imageID string, wlids wlidSet) {
+	if m.wlidsByImageID == nil {
+		m.init()
+	}
+	m.wlidsByImageID[imageID] = wlids
+}
+
+// StoreSet sets a given set of WLIDs for the provided image ID
+func (m *imageIDWLIDMap) StoreSet(imageID string, wlids wlidSet) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setUnsafe(imageID, wlids)
+}
+
+// getUnsafe returns the wlidSet at given image ID
+//
+// NOT THREAD SAFE! Assumes the caller is holding a Read lock.
+func (m *imageIDWLIDMap) getUnsafe(imageID string) (wlidSet, bool) {
+	val, ok := m.wlidsByImageID[imageID]
+	return val, ok
+
+}
+
+// Load returns a slice of WLIds for a given Image ID
+//
+// As the result is logically a set, it does not guarantee a stable order of its elements
+func (m *imageIDWLIDMap) Load(imageID string) ([]string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	val, ok := m.getUnsafe(imageID)
+	if ok {
+		return val.ToSlice(), ok
+	}
+	return nil, ok
+}
+
+// LoadSet returns a copy of a set of WLIDs for the provided imageID
+//
+// This method returns a copy so that callers will not be able to modify the
+// underlying data structures. To modify the map, use its public methods.
+func (m *imageIDWLIDMap) LoadSet(imageID string) (wlidSet, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	val, ok := m.getUnsafe(imageID)
+	if !ok {
+		return val, ok
+	}
+	return val.Clone(), ok
+}
+
+// Clear clears the map and sets it to an empty map
+func (m *imageIDWLIDMap) Clear() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.wlidsByImageID = map[string]wlidSet{}
+}
+
+// Add adds a given list of WLIDs to a provided imageID
+func (m *imageIDWLIDMap) Add(imageID string, wlids ...string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	existingWlids, ok := m.getUnsafe(imageID)
+	if !ok {
+		wlidSet := NewWLIDSet(wlids...)
+		m.setUnsafe(imageID, wlidSet)
+
+	} else {
+		existingWlids.Append(wlids...)
+	}
+}
+
+// Range calls f sequentially over the contents of the map, using WLIDs as slice of string
+func (m *imageIDWLIDMap) Range(f func(imageID string, wlids []string) bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for imageID, wlids := range m.wlidsByImageID {
+		if !f(imageID, wlids.ToSlice()) {
+			return
+		}
+	}
+}
+
+// Map returns a map that corresponds to the state of the data structure at the moment of the call
+//
+// As each value is logically a set, the method does not guarantee a stable order of its elements
+func (m *imageIDWLIDMap) Map() map[string][]string {
+	res := map[string][]string{}
+
+	m.Range(func(imageID string, wlids []string) bool {
+		res[imageID] = wlids
+		return true
+	})
+	return res
+}

--- a/watcher/maps_test.go
+++ b/watcher/maps_test.go
@@ -33,18 +33,18 @@ func TestWLIDSetNew(t *testing.T) {
 }
 
 func TestImageIDWLIDsMapNew(t *testing.T) {
-	iwMap := NewImageIDWLIDsMap()
+	iwMap := NewImageHashWLIDsMap()
 
 	assert.NotNilf(t, iwMap, "Returned map should not be nil")
 }
 
-func assertRawMapEqualsIWMap(t *testing.T, rawMap map[string][]string, iwMap *imageIDWLIDMap) {
+func assertRawMapEqualsIWMap(t *testing.T, rawMap map[string][]string, iwMap *imageHashWLIDMap) {
 	allKeys := make([]string, 0)
 
 	for k := range rawMap {
 		allKeys = append(allKeys, k)
 	}
-	for k := range iwMap.wlidsByImageID {
+	for k := range iwMap.wlidsByImageHash {
 		allKeys = append(allKeys, k)
 	}
 
@@ -77,14 +77,14 @@ func TestImageIDWLIDsMapNewFrom(t *testing.T) {
 		{
 			name: "Non-empty starting values construct a matching map",
 			startingValues: map[string][]string{
-				"imageID": {"wlid-01"},
+				"imageHash": {"wlid-01"},
 			},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+			iwMap := NewImageHashWLIDsMapFrom(tc.startingValues)
 
 			assert.NotNilf(t, iwMap, "Returned map should not be nil")
 			assertRawMapEqualsIWMap(t, tc.startingValues, iwMap)
@@ -140,7 +140,7 @@ func TestImageIDWLIDsMapStoreSetAndLoadSet(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMap()
+			iwMap := NewImageHashWLIDsMap()
 
 			for k, v := range tc.inputKVs {
 				iwMap.StoreSet(k, v)
@@ -185,7 +185,7 @@ func TestImageIDWLIDsMapLoadSetResultImmutable(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMap()
+			iwMap := NewImageHashWLIDsMap()
 			for k, v := range tc.startingMap {
 				iwMap.StoreSet(k, v)
 			}
@@ -212,14 +212,14 @@ func TestImageIDWLIDsMapClear(t *testing.T) {
 		{
 			name: "Clearing a non-empty map should make it an empty map",
 			startingValues: map[string]wlidSet{
-				"imageID": NewWLIDSet("wlid01", "wlid02"),
+				"imageHash": NewWLIDSet("wlid01", "wlid02"),
 			},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMap()
+			iwMap := NewImageHashWLIDsMap()
 			for k, v := range tc.startingValues {
 				iwMap.StoreSet(k, v)
 			}
@@ -241,8 +241,8 @@ func TestImageIDWLIDsMapClear(t *testing.T) {
 
 func TestImageIDWLIDsAdd(t *testing.T) {
 	type iwMapAddOperation struct {
-		imageID string
-		wlids   []string
+		imageHash string
+		wlids     []string
 	}
 
 	tt := []struct {
@@ -252,62 +252,62 @@ func TestImageIDWLIDsAdd(t *testing.T) {
 		expectedMap     map[string][]string
 	}{
 		{
-			name:           "Adding a full imageId-WLIDs pair to an empty map should be reflected",
+			name:           "Adding a full imageHash-WLIDs pair to an empty map should be reflected",
 			startingValues: map[string][]string{},
 			inputOperations: []iwMapAddOperation{
-				{"imageID", []string{"wlid-01", "wlid-02"}},
+				{"imageHash", []string{"wlid-01", "wlid-02"}},
 			},
 			expectedMap: map[string][]string{
-				"imageID": {"wlid-01", "wlid-02"},
+				"imageHash": {"wlid-01", "wlid-02"},
 			},
 		},
 		{
-			name: "Adding WLIDs to existing imageID should extend the set of WLIDs",
+			name: "Adding WLIDs to existing imageHash should extend the set of WLIDs",
 			startingValues: map[string][]string{
-				"imageID": {"wlid-01", "wlid-02"},
+				"imageHash": {"wlid-01", "wlid-02"},
 			},
 			inputOperations: []iwMapAddOperation{
-				{"imageID", []string{"wlid-03"}},
+				{"imageHash", []string{"wlid-03"}},
 			},
 			expectedMap: map[string][]string{
-				"imageID": {"wlid-01", "wlid-02", "wlid-03"},
+				"imageHash": {"wlid-01", "wlid-02", "wlid-03"},
 			},
 		},
 		{
 			name:           "Adding multiple WLIDs to an empty map should store matching WLIDs",
 			startingValues: map[string][]string{},
 			inputOperations: []iwMapAddOperation{
-				{"imageID-01", []string{"wlid-01", "wlid-02"}},
-				{"imageID-02", []string{"wlid-03", "wlid-04"}},
+				{"imageHash-01", []string{"wlid-01", "wlid-02"}},
+				{"imageHash-02", []string{"wlid-03", "wlid-04"}},
 			},
 			expectedMap: map[string][]string{
-				"imageID-01": {"wlid-01", "wlid-02"},
-				"imageID-02": {"wlid-03", "wlid-04"},
+				"imageHash-01": {"wlid-01", "wlid-02"},
+				"imageHash-02": {"wlid-03", "wlid-04"},
 			},
 		},
 		{
 			name: "Adding WLIDs to a existing keys should store matching WLIDs",
 			startingValues: map[string][]string{
-				"imageID-01": {"wlid-01", "wlid-02"},
-				"imageID-02": {"wlid-03", "wlid-04"},
+				"imageHash-01": {"wlid-01", "wlid-02"},
+				"imageHash-02": {"wlid-03", "wlid-04"},
 			},
 			inputOperations: []iwMapAddOperation{
-				{"imageID-01", []string{"wlid-05", "wlid-06"}},
-				{"imageID-02", []string{"wlid-07", "wlid-08"}},
+				{"imageHash-01", []string{"wlid-05", "wlid-06"}},
+				{"imageHash-02", []string{"wlid-07", "wlid-08"}},
 			},
 			expectedMap: map[string][]string{
-				"imageID-01": {"wlid-01", "wlid-02", "wlid-05", "wlid-06"},
-				"imageID-02": {"wlid-03", "wlid-04", "wlid-07", "wlid-08"},
+				"imageHash-01": {"wlid-01", "wlid-02", "wlid-05", "wlid-06"},
+				"imageHash-02": {"wlid-03", "wlid-04", "wlid-07", "wlid-08"},
 			},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+			iwMap := NewImageHashWLIDsMapFrom(tc.startingValues)
 
 			for _, op := range tc.inputOperations {
-				iwMap.Add(op.imageID, op.wlids...)
+				iwMap.Add(op.imageHash, op.wlids...)
 			}
 
 			assertRawMapEqualsIWMap(t, tc.expectedMap, iwMap)
@@ -317,7 +317,7 @@ func TestImageIDWLIDsAdd(t *testing.T) {
 
 func TestImageIDWLIDsMapLoad(t *testing.T) {
 	type loadResult struct {
-		imageID       string
+		imageHash     string
 		expectedWlids []string
 		expectedOk    bool
 	}
@@ -331,13 +331,13 @@ func TestImageIDWLIDsMapLoad(t *testing.T) {
 			name: "Retrieving a slice after storing produces a slice that contains the same elements",
 			testedLoads: []loadResult{
 				{
-					imageID:       "imageID",
+					imageHash:     "imageHash",
 					expectedWlids: []string{"wlid-01", "wlid-02"},
 					expectedOk:    true,
 				},
 			},
 			inputSlices: map[string][]string{
-				"imageID": {"wlid-01", "wlid-02"},
+				"imageHash": {"wlid-01", "wlid-02"},
 			},
 		},
 		{
@@ -345,7 +345,7 @@ func TestImageIDWLIDsMapLoad(t *testing.T) {
 			inputSlices: map[string][]string{},
 			testedLoads: []loadResult{
 				{
-					imageID:       "missing-key",
+					imageHash:     "missing-key",
 					expectedWlids: nil,
 					expectedOk:    false,
 				},
@@ -355,10 +355,10 @@ func TestImageIDWLIDsMapLoad(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMapFrom(tc.inputSlices)
+			iwMap := NewImageHashWLIDsMapFrom(tc.inputSlices)
 
 			for _, tl := range tc.testedLoads {
-				loadedWlids, ok := iwMap.Load(tl.imageID)
+				loadedWlids, ok := iwMap.Load(tl.imageHash)
 
 				assert.ElementsMatch(t, tl.expectedWlids, loadedWlids)
 				assert.Equal(t, tl.expectedOk, ok)
@@ -375,25 +375,25 @@ func TestImageIDWLIDsMapRange(t *testing.T) {
 		{
 			name: "Ranging over the map has access to all values",
 			startingValues: map[string][]string{
-				"imageID-01": {"wlid-01", "wlid-02"},
-				"imageID-02": {"wlid-03", "wlid-04"},
+				"imageHash-01": {"wlid-01", "wlid-02"},
+				"imageHash-02": {"wlid-03", "wlid-04"},
 			},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+			iwMap := NewImageHashWLIDsMapFrom(tc.startingValues)
 
 			visitedKeys := map[string][]string{}
-			iwMap.Range(func(imageID string, wlids []string) bool {
-				visitedKeys[imageID] = wlids
+			iwMap.Range(func(imageHash string, wlids []string) bool {
+				visitedKeys[imageHash] = wlids
 				return true
 			})
 
 			// Since
-			for imageID := range visitedKeys {
-				sort.Strings(visitedKeys[imageID])
+			for imageHash := range visitedKeys {
+				sort.Strings(visitedKeys[imageHash])
 			}
 			assert.Equal(t, tc.startingValues, visitedKeys)
 		})
@@ -409,9 +409,9 @@ func TestImageIDWLIDsMapRangeShortCircuit(t *testing.T) {
 		{
 			name: "Ranging over the map has access to values only before returning false",
 			startingValues: map[string][]string{
-				"imageID-01": {"wlid-01", "wlid-02"},
-				"imageID-02": {"wlid-03", "wlid-04"},
-				"imageID-03": {"wlid-05", "wlid-06"},
+				"imageHash-01": {"wlid-01", "wlid-02"},
+				"imageHash-02": {"wlid-03", "wlid-04"},
+				"imageHash-03": {"wlid-05", "wlid-06"},
 			},
 			expectedVisitedLen: 1,
 		},
@@ -419,12 +419,12 @@ func TestImageIDWLIDsMapRangeShortCircuit(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+			iwMap := NewImageHashWLIDsMapFrom(tc.startingValues)
 
 			visitedKeys := map[string][]string{}
 
-			iwMap.Range(func(imageID string, wlids []string) bool {
-				visitedKeys[imageID] = wlids
+			iwMap.Range(func(imageHash string, wlids []string) bool {
+				visitedKeys[imageHash] = wlids
 				return false
 			})
 
@@ -441,22 +441,22 @@ func TestImageIDWLIDsMapAsMap(t *testing.T) {
 		{
 			name: "Getting as map should return expected values",
 			startingValues: map[string][]string{
-				"imageID-01": {"wlid-01", "wlid-02"},
-				"imageID-02": {"wlid-03", "wlid-04"},
-				"imageID-03": {"wlid-05", "wlid-06"},
+				"imageHash-01": {"wlid-01", "wlid-02"},
+				"imageHash-02": {"wlid-03", "wlid-04"},
+				"imageHash-03": {"wlid-05", "wlid-06"},
 			},
 		},
 	}
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+			iwMap := NewImageHashWLIDsMapFrom(tc.startingValues)
 
 			iwAsMap := iwMap.Map()
 
 			// Ensure consistent ordering of WLIDs
-			for imageID := range iwAsMap {
-				sort.Strings(iwAsMap[imageID])
+			for imageHash := range iwAsMap {
+				sort.Strings(iwAsMap[imageHash])
 			}
 			assert.Equal(t, tc.startingValues, iwAsMap)
 		})

--- a/watcher/maps_test.go
+++ b/watcher/maps_test.go
@@ -1,0 +1,466 @@
+package watcher
+
+import (
+	"sort"
+	"testing"
+
+	sets "github.com/deckarep/golang-set/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWLIDSetNew(t *testing.T) {
+	tt := []struct {
+		name        string
+		inputValues []string
+	}{
+		{
+			name:        "The created set should contain the input values",
+			inputValues: []string{"a", "b"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ws := NewWLIDSet(tc.inputValues...)
+
+			expectedValues := sets.NewSet(tc.inputValues...)
+			if !expectedValues.Equal(ws) {
+				t.Errorf("Given sets are not equal.")
+
+			}
+		})
+	}
+}
+
+func TestImageIDWLIDsMapNew(t *testing.T) {
+	var iwMap *imageIDWLIDMap
+	iwMap = NewImageIDWLIDsMap()
+
+	assert.NotNilf(t, iwMap, "Returned map should not be nil")
+}
+
+func assertRawMapEqualsIWMap(t *testing.T, rawMap map[string][]string, iwMap *imageIDWLIDMap) {
+	allKeys := make([]string, 0)
+
+	for k := range rawMap {
+		allKeys = append(allKeys, k)
+	}
+	for k := range iwMap.wlidsByImageID {
+		allKeys = append(allKeys, k)
+	}
+
+	for _, k := range allKeys {
+		var rawSet, iwSet wlidSet
+
+		rawWlids, ok := rawMap[k]
+		rawSet = NewWLIDSet(rawWlids...)
+
+		iwSet, ok = iwMap.LoadSet(k)
+		if !ok {
+			iwSet = NewWLIDSet()
+		}
+
+		if !rawSet.Equal(iwSet) {
+			t.Errorf("For key %s, sets are not matching. RawSet: %v, IWSet: %v", k, rawSet, iwSet)
+		}
+	}
+}
+
+func TestImageIDWLIDsMapNewFrom(t *testing.T) {
+	tt := []struct {
+		name           string
+		startingValues map[string][]string
+	}{
+		{
+			name:           "Empty starting values construct an empty map",
+			startingValues: map[string][]string{},
+		},
+		{
+			name: "Non-empty starting values construct a matching map",
+			startingValues: map[string][]string{
+				"imageID": {"wlid-01"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+
+			assert.NotNilf(t, iwMap, "Returned map should not be nil")
+			assertRawMapEqualsIWMap(t, tc.startingValues, iwMap)
+		})
+	}
+}
+
+func TestImageIDWLIDsMapStoreSetAndLoadSet(t *testing.T) {
+	tt := []struct {
+		name        string
+		inputKVs    map[string]wlidSet
+		expectedKVs map[string]wlidSet
+		expectedOks map[string]bool
+	}{
+		{
+			name: "Storing a single value should return a matching value",
+			inputKVs: map[string]wlidSet{
+				"someImageID": NewWLIDSet("someWLID"),
+			},
+			expectedKVs: map[string]wlidSet{
+				"someImageID": NewWLIDSet("someWLID"),
+			},
+			expectedOks: map[string]bool{
+				"someImageID": true,
+			},
+		},
+		{
+			name: "Storing multiple keys should return matching values",
+			inputKVs: map[string]wlidSet{
+				"someImageID":      NewWLIDSet("someWLID"),
+				"someOtherImageID": NewWLIDSet("someOtherWLID"),
+			},
+			expectedKVs: map[string]wlidSet{
+				"someImageID":      NewWLIDSet("someWLID"),
+				"someOtherImageID": NewWLIDSet("someOtherWLID"),
+			},
+			expectedOks: map[string]bool{
+				"someImageID":      true,
+				"someOtherImageID": true,
+			},
+		},
+		{
+			name:     "Getting from empty map should return a NOT ok flag",
+			inputKVs: map[string]wlidSet{},
+			expectedKVs: map[string]wlidSet{
+				"someImageID": nil,
+			},
+			expectedOks: map[string]bool{
+				"someImageID": false,
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMap()
+
+			for k, v := range tc.inputKVs {
+				iwMap.StoreSet(k, v)
+			}
+
+			actualKVs := map[string]wlidSet{}
+			for k := range tc.expectedKVs {
+				actualValue, _ := iwMap.LoadSet(k)
+				actualKVs[k] = actualValue
+			}
+
+			actualOks := map[string]bool{}
+			for k := range tc.expectedOks {
+				_, ok := iwMap.LoadSet(k)
+				actualOks[k] = ok
+			}
+
+			assert.Equalf(t, tc.expectedKVs, actualKVs, "Stored value must match the input value")
+			assert.Equalf(t, tc.expectedOks, actualOks, "Actual OKs must match the expected OKs")
+		})
+	}
+}
+
+func TestImageIDWLIDsMapLoadSetResultImmutable(t *testing.T) {
+	tt := []struct {
+		name        string
+		startingMap map[string]wlidSet
+		appendInput []string
+		testKey     string
+		expected    wlidSet
+	}{
+		{
+			name: "Plain appending to a Get result of a map should not mutate the underlying map",
+			startingMap: map[string]wlidSet{
+				"some": NewWLIDSet("first", "second"),
+			},
+			testKey:     "some",
+			appendInput: []string{"INTRUDER"},
+			expected:    NewWLIDSet("first", "second"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMap()
+			for k, v := range tc.startingMap {
+				iwMap.StoreSet(k, v)
+			}
+			got, _ := iwMap.LoadSet(tc.testKey)
+
+			for _, input := range tc.appendInput {
+				got.Add(input)
+			}
+
+			actual, _ := iwMap.LoadSet(tc.testKey)
+
+			if !actual.Equal(tc.expected) {
+				t.Errorf("Sets are not equal. Got: %v, want: %v", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestImageIDWLIDsMapClear(t *testing.T) {
+	tt := []struct {
+		name           string
+		startingValues map[string]wlidSet
+	}{
+		{
+			name: "Clearing a non-empty map should make it an empty map",
+			startingValues: map[string]wlidSet{
+				"imageID": NewWLIDSet("wlid01", "wlid02"),
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMap()
+			for k, v := range tc.startingValues {
+				iwMap.StoreSet(k, v)
+			}
+
+			iwMap.Clear()
+
+			remainingValues := map[string]wlidSet{}
+			for k := range tc.startingValues {
+				remainingValue, ok := iwMap.LoadSet(k)
+				if ok {
+					remainingValues[k] = remainingValue
+				}
+			}
+			expectedRemainingValues := map[string]wlidSet{}
+			assert.Equal(t, expectedRemainingValues, remainingValues)
+		})
+	}
+}
+
+func TestImageIDWLIDsAdd(t *testing.T) {
+	type iwMapAddOperation struct {
+		imageID string
+		wlids   []string
+	}
+
+	tt := []struct {
+		name            string
+		startingValues  map[string][]string
+		inputOperations []iwMapAddOperation
+		expectedMap     map[string][]string
+	}{
+		{
+			name:           "Adding a full imageId-WLIDs pair to an empty map should be reflected",
+			startingValues: map[string][]string{},
+			inputOperations: []iwMapAddOperation{
+				{"imageID", []string{"wlid-01", "wlid-02"}},
+			},
+			expectedMap: map[string][]string{
+				"imageID": {"wlid-01", "wlid-02"},
+			},
+		},
+		{
+			name: "Adding WLIDs to existing imageID should extend the set of WLIDs",
+			startingValues: map[string][]string{
+				"imageID": {"wlid-01", "wlid-02"},
+			},
+			inputOperations: []iwMapAddOperation{
+				{"imageID", []string{"wlid-03"}},
+			},
+			expectedMap: map[string][]string{
+				"imageID": {"wlid-01", "wlid-02", "wlid-03"},
+			},
+		},
+		{
+			name:           "Adding multiple WLIDs to an empty map should store matching WLIDs",
+			startingValues: map[string][]string{},
+			inputOperations: []iwMapAddOperation{
+				{"imageID-01", []string{"wlid-01", "wlid-02"}},
+				{"imageID-02", []string{"wlid-03", "wlid-04"}},
+			},
+			expectedMap: map[string][]string{
+				"imageID-01": {"wlid-01", "wlid-02"},
+				"imageID-02": {"wlid-03", "wlid-04"},
+			},
+		},
+		{
+			name: "Adding WLIDs to a existing keys should store matching WLIDs",
+			startingValues: map[string][]string{
+				"imageID-01": {"wlid-01", "wlid-02"},
+				"imageID-02": {"wlid-03", "wlid-04"},
+			},
+			inputOperations: []iwMapAddOperation{
+				{"imageID-01", []string{"wlid-05", "wlid-06"}},
+				{"imageID-02", []string{"wlid-07", "wlid-08"}},
+			},
+			expectedMap: map[string][]string{
+				"imageID-01": {"wlid-01", "wlid-02", "wlid-05", "wlid-06"},
+				"imageID-02": {"wlid-03", "wlid-04", "wlid-07", "wlid-08"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+
+			for _, op := range tc.inputOperations {
+				iwMap.Add(op.imageID, op.wlids...)
+			}
+
+			assertRawMapEqualsIWMap(t, tc.expectedMap, iwMap)
+		})
+	}
+}
+
+func TestImageIDWLIDsMapLoad(t *testing.T) {
+	type loadResult struct {
+		imageID       string
+		expectedWlids []string
+		expectedOk    bool
+	}
+
+	tt := []struct {
+		name        string
+		inputSlices map[string][]string
+		testedLoads []loadResult
+	}{
+		{
+			name: "Retrieving a slice after storing produces a slice that contains the same elements",
+			testedLoads: []loadResult{
+				{
+					imageID:       "imageID",
+					expectedWlids: []string{"wlid-01", "wlid-02"},
+					expectedOk:    true,
+				},
+			},
+			inputSlices: map[string][]string{
+				"imageID": {"wlid-01", "wlid-02"},
+			},
+		},
+		{
+			name:        "Retrieving a slice from an empty map should return nil and NOT ok",
+			inputSlices: map[string][]string{},
+			testedLoads: []loadResult{
+				{
+					imageID:       "missing-key",
+					expectedWlids: nil,
+					expectedOk:    false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMapFrom(tc.inputSlices)
+
+			for _, tl := range tc.testedLoads {
+				loadedWlids, ok := iwMap.Load(tl.imageID)
+
+				assert.ElementsMatch(t, tl.expectedWlids, loadedWlids)
+				assert.Equal(t, tl.expectedOk, ok)
+			}
+		})
+	}
+}
+
+func TestImageIDWLIDsMapRange(t *testing.T) {
+	tt := []struct {
+		name           string
+		startingValues map[string][]string
+	}{
+		{
+			name: "Ranging over the map has access to all values",
+			startingValues: map[string][]string{
+				"imageID-01": {"wlid-01", "wlid-02"},
+				"imageID-02": {"wlid-03", "wlid-04"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+
+			visitedKeys := map[string][]string{}
+			iwMap.Range(func(imageID string, wlids []string) bool {
+				visitedKeys[imageID] = wlids
+				return true
+			})
+
+			// Since
+			for imageID := range visitedKeys {
+				sort.Strings(visitedKeys[imageID])
+			}
+			assert.Equal(t, tc.startingValues, visitedKeys)
+		})
+	}
+}
+
+func TestImageIDWLIDsMapRangeShortCircuit(t *testing.T) {
+	tt := []struct {
+		name               string
+		startingValues     map[string][]string
+		expectedVisitedLen int
+	}{
+		{
+			name: "Ranging over the map has access to values only before returning false",
+			startingValues: map[string][]string{
+				"imageID-01": {"wlid-01", "wlid-02"},
+				"imageID-02": {"wlid-03", "wlid-04"},
+				"imageID-03": {"wlid-05", "wlid-06"},
+			},
+			expectedVisitedLen: 1,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+
+			visitedKeys := map[string][]string{}
+
+			iwMap.Range(func(imageID string, wlids []string) bool {
+				visitedKeys[imageID] = wlids
+				return false
+			})
+
+			assert.Equal(t, tc.expectedVisitedLen, len(visitedKeys))
+		})
+	}
+}
+
+
+func TestImageIDWLIDsMapAsMap(t *testing.T) {
+	tt := []struct{
+		name string
+		startingValues map[string][]string
+	}{
+		{
+			name: "Getting as map should return expected values",
+			startingValues: map[string][]string{
+				"imageID-01": {"wlid-01", "wlid-02"},
+				"imageID-02": {"wlid-03", "wlid-04"},
+				"imageID-03": {"wlid-05", "wlid-06"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			iwMap := NewImageIDWLIDsMapFrom(tc.startingValues)
+
+			iwAsMap := iwMap.Map()
+
+			// Ensure consistent ordering of WLIDs
+			for imageID := range iwAsMap {
+				sort.Strings(iwAsMap[imageID])
+			}
+			assert.Equal(t, tc.startingValues, iwAsMap)
+		})
+	}
+}

--- a/watcher/maps_test.go
+++ b/watcher/maps_test.go
@@ -33,8 +33,7 @@ func TestWLIDSetNew(t *testing.T) {
 }
 
 func TestImageIDWLIDsMapNew(t *testing.T) {
-	var iwMap *imageIDWLIDMap
-	iwMap = NewImageIDWLIDsMap()
+	iwMap := NewImageIDWLIDsMap()
 
 	assert.NotNilf(t, iwMap, "Returned map should not be nil")
 }
@@ -52,10 +51,10 @@ func assertRawMapEqualsIWMap(t *testing.T, rawMap map[string][]string, iwMap *im
 	for _, k := range allKeys {
 		var rawSet, iwSet wlidSet
 
-		rawWlids, ok := rawMap[k]
+		rawWlids := rawMap[k]
 		rawSet = NewWLIDSet(rawWlids...)
 
-		iwSet, ok = iwMap.LoadSet(k)
+		iwSet, ok := iwMap.LoadSet(k)
 		if !ok {
 			iwSet = NewWLIDSet()
 		}
@@ -434,10 +433,9 @@ func TestImageIDWLIDsMapRangeShortCircuit(t *testing.T) {
 	}
 }
 
-
 func TestImageIDWLIDsMapAsMap(t *testing.T) {
-	tt := []struct{
-		name string
+	tt := []struct {
+		name           string
 		startingValues map[string][]string
 	}{
 		{

--- a/watcher/maps_test.go
+++ b/watcher/maps_test.go
@@ -77,7 +77,7 @@ func TestImageIDWLIDsMapNewFrom(t *testing.T) {
 		{
 			name: "Non-empty starting values construct a matching map",
 			startingValues: map[string][]string{
-				"imageHash": {"wlid-01"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01"},
 			},
 		},
 	}
@@ -212,7 +212,7 @@ func TestImageIDWLIDsMapClear(t *testing.T) {
 		{
 			name: "Clearing a non-empty map should make it an empty map",
 			startingValues: map[string]wlidSet{
-				"imageHash": NewWLIDSet("wlid01", "wlid02"),
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": NewWLIDSet("wlid01", "wlid02"),
 			},
 		},
 	}
@@ -255,49 +255,49 @@ func TestImageIDWLIDsAdd(t *testing.T) {
 			name:           "Adding a full imageHash-WLIDs pair to an empty map should be reflected",
 			startingValues: map[string][]string{},
 			inputOperations: []iwMapAddOperation{
-				{"imageHash", []string{"wlid-01", "wlid-02"}},
+				{"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047", []string{"wlid-01", "wlid-02"}},
 			},
 			expectedMap: map[string][]string{
-				"imageHash": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
 			},
 		},
 		{
 			name: "Adding WLIDs to existing imageHash should extend the set of WLIDs",
 			startingValues: map[string][]string{
-				"imageHash": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
 			},
 			inputOperations: []iwMapAddOperation{
-				{"imageHash", []string{"wlid-03"}},
+				{"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047", []string{"wlid-03"}},
 			},
 			expectedMap: map[string][]string{
-				"imageHash": {"wlid-01", "wlid-02", "wlid-03"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02", "wlid-03"},
 			},
 		},
 		{
 			name:           "Adding multiple WLIDs to an empty map should store matching WLIDs",
 			startingValues: map[string][]string{},
 			inputOperations: []iwMapAddOperation{
-				{"imageHash-01", []string{"wlid-01", "wlid-02"}},
-				{"imageHash-02", []string{"wlid-03", "wlid-04"}},
+				{"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047", []string{"wlid-01", "wlid-02"}},
+				{"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048", []string{"wlid-03", "wlid-04"}},
 			},
 			expectedMap: map[string][]string{
-				"imageHash-01": {"wlid-01", "wlid-02"},
-				"imageHash-02": {"wlid-03", "wlid-04"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048": {"wlid-03", "wlid-04"},
 			},
 		},
 		{
-			name: "Adding WLIDs to a existing keys should store matching WLIDs",
+			name: "Adding WLIDs to existing keys should store matching WLIDs",
 			startingValues: map[string][]string{
-				"imageHash-01": {"wlid-01", "wlid-02"},
-				"imageHash-02": {"wlid-03", "wlid-04"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048": {"wlid-03", "wlid-04"},
 			},
 			inputOperations: []iwMapAddOperation{
-				{"imageHash-01", []string{"wlid-05", "wlid-06"}},
-				{"imageHash-02", []string{"wlid-07", "wlid-08"}},
+				{"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047", []string{"wlid-05", "wlid-06"}},
+				{"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048", []string{"wlid-07", "wlid-08"}},
 			},
 			expectedMap: map[string][]string{
-				"imageHash-01": {"wlid-01", "wlid-02", "wlid-05", "wlid-06"},
-				"imageHash-02": {"wlid-03", "wlid-04", "wlid-07", "wlid-08"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02", "wlid-05", "wlid-06"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048": {"wlid-03", "wlid-04", "wlid-07", "wlid-08"},
 			},
 		},
 	}
@@ -331,13 +331,13 @@ func TestImageIDWLIDsMapLoad(t *testing.T) {
 			name: "Retrieving a slice after storing produces a slice that contains the same elements",
 			testedLoads: []loadResult{
 				{
-					imageHash:     "imageHash",
+					imageHash:     "7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047",
 					expectedWlids: []string{"wlid-01", "wlid-02"},
 					expectedOk:    true,
 				},
 			},
 			inputSlices: map[string][]string{
-				"imageHash": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
 			},
 		},
 		{
@@ -375,8 +375,8 @@ func TestImageIDWLIDsMapRange(t *testing.T) {
 		{
 			name: "Ranging over the map has access to all values",
 			startingValues: map[string][]string{
-				"imageHash-01": {"wlid-01", "wlid-02"},
-				"imageHash-02": {"wlid-03", "wlid-04"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048": {"wlid-03", "wlid-04"},
 			},
 		},
 	}
@@ -409,9 +409,9 @@ func TestImageIDWLIDsMapRangeShortCircuit(t *testing.T) {
 		{
 			name: "Ranging over the map has access to values only before returning false",
 			startingValues: map[string][]string{
-				"imageHash-01": {"wlid-01", "wlid-02"},
-				"imageHash-02": {"wlid-03", "wlid-04"},
-				"imageHash-03": {"wlid-05", "wlid-06"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048": {"wlid-03", "wlid-04"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0049": {"wlid-05", "wlid-06"},
 			},
 			expectedVisitedLen: 1,
 		},
@@ -441,9 +441,9 @@ func TestImageIDWLIDsMapAsMap(t *testing.T) {
 		{
 			name: "Getting as map should return expected values",
 			startingValues: map[string][]string{
-				"imageHash-01": {"wlid-01", "wlid-02"},
-				"imageHash-02": {"wlid-03", "wlid-04"},
-				"imageHash-03": {"wlid-05", "wlid-06"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0047": {"wlid-01", "wlid-02"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0048": {"wlid-03", "wlid-04"},
+				"7238b08a6bad494e84ed1c632a62d39bdeed1f929950a05c1a32b6d4490a0049": {"wlid-05", "wlid-06"},
 			},
 		},
 	}

--- a/watcher/utils.go
+++ b/watcher/utils.go
@@ -4,6 +4,11 @@ import (
 	"github.com/armosec/armoapi-go/apis"
 	"github.com/kubescape/operator/utils"
 	core1 "k8s.io/api/core/v1"
+	"regexp"
+)
+
+var (
+	imageHashRegExp = regexp.MustCompile(`^[0-9a-f]+$`)
 )
 
 func extractImageIDsToContainersFromPod(pod *core1.Pod) map[string][]string {
@@ -49,4 +54,17 @@ func getImageScanCommand(wlid string, containerToimageID map[string]string) *api
 		CommandName: apis.TypeScanImages,
 		Args:        map[string]interface{}{utils.ContainerToImageIdsArg: containerToimageID},
 	}
+}
+
+func extractImageHash(imageID string) (string, error) {
+	if len(imageID) < 64 {
+		return "", errInvalidImageID
+	}
+
+	candidateValue := imageID[len(imageID)-64:]
+	if imageHashRegExp.MatchString(candidateValue) {
+		return candidateValue, nil
+	}
+
+	return "", errInvalidImageID
 }

--- a/watcher/utils_test.go
+++ b/watcher/utils_test.go
@@ -191,3 +191,54 @@ func Test_extractImageIDsFromPod(t *testing.T) {
 		})
 	}
 }
+
+func Test_extractImageHash(t *testing.T) {
+	tt := []struct {
+		name              string
+		inputImageID      string
+		expectedImageHash string
+		expectedError     error
+	}{
+		{
+			name:              "Extracting from imageHash should return the same hash",
+			inputImageID:      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+			expectedImageHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		},
+		{
+			name:              "Extracting from hashType:imageHash should return the expected hash",
+			inputImageID:      "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+			expectedImageHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		},
+		{
+			name:              "Extracting from imageTag@hashType:imageHash should return the expected hash",
+			inputImageID:      "alpine@sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+			expectedImageHash: "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		},
+		{
+			name:              "Extracting from repoName/imageTag@hashType:imageHash should return the expected hash",
+			inputImageID:      "registry.k8s.io/kube-apiserver:v1.25.4@sha256:00631e54acba3a4d507a9f7b7095a81151b8a8f909f93e50f64269ea39daf2cf",
+			expectedImageHash: "00631e54acba3a4d507a9f7b7095a81151b8a8f909f93e50f64269ea39daf2cf",
+		},
+		{
+			name:              "Extracting from invalid value less than 64 chars should return an error",
+			inputImageID:      "this is definitely not a valid imageID",
+			expectedImageHash: "",
+			expectedError:     errInvalidImageID,
+		},
+		{
+			name:              "Extracting from invalid value over 63 chars should return an error",
+			inputImageID:      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234567890!@#$%^&*()",
+			expectedImageHash: "",
+			expectedError:     errInvalidImageID,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			actualImageHash, err := extractImageHash(tc.inputImageID)
+
+			assert.Equal(t, tc.expectedImageHash, actualImageHash)
+			assert.Equal(t, tc.expectedError, err)
+		})
+	}
+}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -76,7 +76,7 @@ func (wh *WatchHandler) cleanUp(ctx context.Context) {
 	// image IDs in storage that are not in current map should be deleted
 	imageIDsForDeletion := make([]string, 0)
 	for _, imageID := range storageImageIDs {
-		if !wh.isImageIDInMap(imageID) {
+		if _, imageIDinMap := wh.iwMap.Load(imageID); !imageIDinMap {
 			imageIDsForDeletion = append(imageIDsForDeletion, imageID)
 		}
 	}
@@ -160,12 +160,6 @@ func (wh *WatchHandler) listInstanceIDs() []string {
 	defer wh.instanceIDsMutex.RUnlock()
 
 	return wh.instanceIDs
-}
-
-// returns true if imageID is in map
-func (wh *WatchHandler) isImageIDInMap(imageID string) bool {
-	_, ok := wh.iwMap.LoadSet(imageID)
-	return ok
 }
 
 // returns wlids map
@@ -457,7 +451,7 @@ func (wh *WatchHandler) getNewContainerToImageIDsFromPod(pod *core1.Pod) map[str
 
 	for imageID, containers := range imageIDsToContainers {
 		for _, container := range containers {
-			if !wh.isImageIDInMap(imageID) {
+			if _, imageIDinMap := wh.iwMap.Load(imageID); !imageIDinMap {
 				newContainerToImageIDs[container] = imageID
 			}
 		}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -288,12 +288,8 @@ func (wh *WatchHandler) ListImageIDsFromStorage() ([]string, error) {
 }
 
 func (wh *WatchHandler) cleanUpIDs() {
-	wh.cleanUpImagesIDToWlidsMap()
-	wh.cleanUpWlidsToContainerToImageIDMap()
-}
-
-func (wh *WatchHandler) cleanUpImagesIDToWlidsMap() {
 	wh.iwMap.Clear()
+	wh.cleanUpWlidsToContainerToImageIDMap()
 }
 
 func (wh *WatchHandler) cleanUpWlidsToContainerToImageIDMap() {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -170,11 +170,6 @@ func (wh *WatchHandler) getWlidsToContainerToImageIDMap() WlidsToContainerToImag
 	return wh.wlidsToContainerToImageIDMap
 }
 
-// returns imageIDs map
-func (wh *WatchHandler) getImagesIDsToWlidMap() map[string][]string {
-	return wh.iwMap.Map()
-}
-
 // HandleSBOMEvents handles SBOM-related events
 //
 // Handling events is defined as dispatching scan commands that match a given

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -24,8 +24,8 @@ import (
 )
 
 var (
-	ErrUnsupportedObject = errors.New("Unsupported object type")
-	ErrUnknownImageID    = errors.New("Unknown image ID")
+	ErrUnsupportedObject = errors.New("unsupported object type")
+	ErrUnknownImageHash  = errors.New("unknown image hash")
 )
 
 type WlidsToContainerToImageIDMap map[string]map[string]string
@@ -191,11 +191,11 @@ func (wh *WatchHandler) HandleSBOMEvents(sbomEvents <-chan watch.Event, commands
 			continue
 		}
 
-		imageID := obj.ObjectMeta.Name
+		imageHash := obj.ObjectMeta.Name
 
-		wlids, ok := wh.iwMap.Load(imageID)
+		wlids, ok := wh.iwMap.Load(imageHash)
 		if !ok {
-			errorCh <- ErrUnknownImageID
+			errorCh <- ErrUnknownImageHash
 			continue
 		}
 
@@ -312,17 +312,17 @@ func (wh *WatchHandler) ListImageIDsNotInStorage(ctx context.Context) ([]string,
 		// logger.L().Ctx(ctx).Error(fmt.Sprintf("error to ListImageIDsFromStorage, err :%s", err.Error()), helpers.Error(err))
 	}
 
-	wh.iwMap.Range(func(imageID string, wlids []string) bool {
-		if !slices.Contains(imageIDsFromStorage, imageID) {
-			newImageIDs = append(newImageIDs, imageID)
+	wh.iwMap.Range(func(imageHash string, wlids []string) bool {
+		if !slices.Contains(imageIDsFromStorage, imageHash) {
+			newImageIDs = append(newImageIDs, imageHash)
 		}
 		return true
 	})
 	return newImageIDs, nil
 }
 
-func (wh *WatchHandler) GetWlidsForImageID(imageID string) []string {
-	wlids, ok := wh.iwMap.Load(imageID)
+func (wh *WatchHandler) GetWlidsForImageHash(imageHash string) []string {
+	wlids, ok := wh.iwMap.Load(imageHash)
 	if !ok {
 		return []string{}
 	}
@@ -353,7 +353,7 @@ func (wh *WatchHandler) addToImageIDToWlidsMap(imageID string, wlids ...string) 
 	if len(wlids) == 0 {
 		return
 	}
-	imageID = utils.ExtractImageID(imageID)
+	imageID, _ = extractImageHash(imageID)
 	wh.iwMap.Add(imageID, wlids...)
 }
 

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -35,7 +35,7 @@ const retryInterval = 3 * time.Second
 type WatchHandler struct {
 	k8sAPI                            *k8sinterface.KubernetesApi
 	storageClient                     kssc.Interface
-	iwMap                             *imageIDWLIDMap
+	iwMap                             *imageHashWLIDMap
 	instanceIDs                       []string
 	instanceIDsMutex                  *sync.RWMutex
 	wlidsToContainerToImageIDMap      WlidsToContainerToImageIDMap // <wlid> : <containerName> : imageID
@@ -105,7 +105,7 @@ func NewWatchHandler(ctx context.Context, k8sAPI *k8sinterface.KubernetesApi, st
 	wh := &WatchHandler{
 		storageClient:                     storageClient,
 		k8sAPI:                            k8sAPI,
-		iwMap:                             NewImageIDWLIDsMapFrom(imageIDsToWLIDsMap),
+		iwMap:                             NewImageHashWLIDsMapFrom(imageIDsToWLIDsMap),
 		wlidsToContainerToImageIDMap:      make(WlidsToContainerToImageIDMap),
 		wlidsToContainerToImageIDMapMutex: &sync.RWMutex{},
 		instanceIDsMutex:                  &sync.RWMutex{},

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"reflect"
+	"sort"
 	"sync"
 	"testing"
 
@@ -22,24 +23,58 @@ import (
 
 func NewWatchHandlerMock() *WatchHandler {
 	return &WatchHandler{
-		imagesIDToWlidsMap:                make(map[string][]string),
+		iwMap:                             NewImageIDWLIDsMap(),
 		wlidsToContainerToImageIDMap:      make(map[string]map[string]string),
-		imageIDsMapMutex:                  &sync.RWMutex{},
 		wlidsToContainerToImageIDMapMutex: &sync.RWMutex{},
 		instanceIDsMutex:                  &sync.RWMutex{},
 	}
 }
 
 func TestNewWatchHandlerProducesValidResult(t *testing.T) {
-	ctx := context.TODO()
-	k8sClient := k8sfake.NewSimpleClientset()
-	k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
-	storageClient := kssfake.NewSimpleClientset()
+	tt := []struct {
+		name string
+		imageIDsToWLIDSsMap map[string][]string
+		expectedIWMap map[string][]string
+	}{
+		{
+			name: "Creating with provided empty map returns matching empty map",
+			imageIDsToWLIDSsMap: map[string][]string{},
+			expectedIWMap: map[string][]string{},
+		},
+		{
+			name: "Creating with provided nil map returns matching empty map",
+			imageIDsToWLIDSsMap: nil,
+			expectedIWMap: map[string][]string{},
+		},
+		{
+			name: "Creating with provided non-empty map returns matching map",
+			imageIDsToWLIDSsMap: map[string][]string{
+				"imageid-01": {"wlid-01"},
+			},
+			expectedIWMap: map[string][]string{
+				"imageid-01": {"wlid-01"},
+			},
+		},
+	}
 
-	wh, err := NewWatchHandler(ctx, k8sAPI, storageClient)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.TODO()
+			k8sClient := k8sfake.NewSimpleClientset()
+			k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
+			storageClient := kssfake.NewSimpleClientset()
 
-	assert.NoErrorf(t, err, "Constructing should produce no errors")
-	assert.NotNilf(t, wh, "Constructing should create a non-nil object")
+			wh, err := NewWatchHandler(ctx, k8sAPI, storageClient, tc.imageIDsToWLIDSsMap)
+
+			actualMap := wh.iwMap.Map()
+			for imageID := range actualMap {
+				sort.Strings(actualMap[imageID])
+			}
+			assert.NoErrorf(t, err, "Constructing should produce no errors")
+			assert.NotNilf(t, wh, "Constructing should create a non-nil object")
+			assert.Equal(t, tc.expectedIWMap, actualMap)
+		})
+	}
 }
 
 func Test_getSBOMWatcher(t *testing.T) {
@@ -47,7 +82,7 @@ func Test_getSBOMWatcher(t *testing.T) {
 	k8sClient := k8sfake.NewSimpleClientset()
 	k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
 	storageClient := kssfake.NewSimpleClientset()
-	wh, _ := NewWatchHandler(ctx, k8sAPI, storageClient)
+	wh, _ := NewWatchHandler(ctx, k8sAPI, storageClient, nil)
 
 	sbomWatcher, err := wh.getSBOMWatcher()
 
@@ -115,7 +150,7 @@ func TestHandleSBOMProducesMatchingCommands(t *testing.T) {
 			ksStorageClient := kssfake.NewSimpleClientset()
 
 			k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
-			wh, _ := NewWatchHandler(ctx, k8sAPI, ksStorageClient)
+			wh, _ := NewWatchHandler(ctx, k8sAPI, ksStorageClient, tc.wlidMap)
 
 			commandCh := make(chan *apis.Command)
 			errors := make(chan error)
@@ -127,7 +162,6 @@ func TestHandleSBOMProducesMatchingCommands(t *testing.T) {
 
 			// Handling the event is expected to transform
 			// incloming imageID in the SBOM name to a valid WLID
-			wh.imagesIDToWlidsMap = tc.wlidMap
 			expectedWlidsCounter := map[string]int{}
 
 			for _, sbom := range tc.sboms {
@@ -370,9 +404,7 @@ func TestHandleSBOMEvents(t *testing.T) {
 
 			k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
 			ksStorageClient := kssfake.NewSimpleClientset()
-			wh, _ := NewWatchHandler(context.TODO(), k8sAPI, ksStorageClient)
-
-			wh.imagesIDToWlidsMap = tc.imageIDstoWlids
+			wh, _ := NewWatchHandler(context.TODO(), k8sAPI, ksStorageClient, tc.imageIDstoWlids)
 
 			commandsCh := make(chan *apis.Command)
 			errCh := make(chan error)
@@ -424,16 +456,14 @@ func TestSBOMWatch(t *testing.T) {
 
 	k8sClient := k8sfake.NewSimpleClientset()
 
-	k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
-	ksStorageClient := kssfake.NewSimpleClientset()
-	wh, _ := NewWatchHandler(context.TODO(), k8sAPI, ksStorageClient)
-
 	expectedWlid := "some-imageID"
 	imageIDsToWlids := map[string][]string{
 		"some-imageID": {expectedWlid},
 	}
 
-	wh.imagesIDToWlidsMap = imageIDsToWlids
+	k8sAPI := utils.NewK8sInterfaceFake(k8sClient)
+	ksStorageClient := kssfake.NewSimpleClientset()
+	wh, _ := NewWatchHandler(context.TODO(), k8sAPI, ksStorageClient, imageIDsToWlids)
 
 	sessionObjCh := make(chan utils.SessionObj)
 	sessionObjChPtr := &sessionObjCh
@@ -757,10 +787,15 @@ func TestAddToImageIDToWlidsMap(t *testing.T) {
 	// add the new wlid to the same imageID
 	wh.addToImageIDToWlidsMap("alpine@sha256:1", "wlid3")
 
-	assert.True(t, reflect.DeepEqual(wh.getImagesIDsToWlidMap(), map[string][]string{
+	actualMap := wh.iwMap.Map()
+	for imageID := range actualMap {
+		sort.Strings(actualMap[imageID])
+	}
+
+	assert.Equal(t, map[string][]string{
 		"alpine@sha256:1": {"wlid1", "wlid3"},
 		"alpine@sha256:2": {"wlid2"},
-	}))
+	}, actualMap)
 }
 
 func TestAddTowlidsToContainerToImageIDMap(t *testing.T) {
@@ -782,11 +817,11 @@ func TestAddTowlidsToContainerToImageIDMap(t *testing.T) {
 func TestGetNewImageIDsToContainerFromPod(t *testing.T) {
 	wh := NewWatchHandlerMock()
 
-	wh.imagesIDToWlidsMap = map[string][]string{
+	wh.iwMap = NewImageIDWLIDsMapFrom(map[string][]string{
 		"alpine@sha256:1": {"wlid"},
 		"alpine@sha256:2": {"wlid"},
 		"alpine@sha256:3": {"wlid"},
-	}
+	})
 
 	tests := []struct {
 		name     string
@@ -867,21 +902,21 @@ func TestGetNewImageIDsToContainerFromPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.True(t, reflect.DeepEqual(wh.getNewContainerToImageIDsFromPod(tt.pod), tt.expected))
+			assert.Equal(t, tt.expected, wh.getNewContainerToImageIDsFromPod(tt.pod))
 		})
 	}
 }
 
 func TestCleanUpImagesIDToWlidsMap(t *testing.T) {
 	wh := NewWatchHandlerMock()
-	wh.imagesIDToWlidsMap = map[string][]string{
+	wh.iwMap = NewImageIDWLIDsMapFrom(map[string][]string{
 		"alpine@sha256:1": {"pod1"},
 		"alpine@sha256:2": {"pod2"},
 		"alpine@sha256:3": {"pod3"},
-	}
+	})
 	wh.cleanUpImagesIDToWlidsMap()
 
-	assert.Equal(t, len(wh.imagesIDToWlidsMap), 0)
+	assert.Equal(t, 0, len(wh.iwMap.Map()))
 }
 
 func TestCleanUpWlidsToContainerToImageIDMap(t *testing.T) {
@@ -898,11 +933,11 @@ func TestCleanUpWlidsToContainerToImageIDMap(t *testing.T) {
 
 func Test_cleanUpIDs(t *testing.T) {
 	wh := NewWatchHandlerMock()
-	wh.imagesIDToWlidsMap = map[string][]string{
+	wh.iwMap = NewImageIDWLIDsMapFrom(map[string][]string{
 		"alpine@sha256:1": {"pod1"},
 		"alpine@sha256:2": {"pod2"},
 		"alpine@sha256:3": {"pod3"},
-	}
+	})
 	wh.wlidsToContainerToImageIDMap = map[string]map[string]string{
 		"pod1": {"container1": "alpine@sha256:1"},
 		"pod2": {"container2": "alpine@sha256:2"},
@@ -910,8 +945,8 @@ func Test_cleanUpIDs(t *testing.T) {
 	}
 	wh.cleanUpIDs()
 
-	assert.Equal(t, len(wh.imagesIDToWlidsMap), 0)
-	assert.Equal(t, len(wh.wlidsToContainerToImageIDMap), 0)
+	assert.Equal(t, 0, len(wh.iwMap.Map()))
+	assert.Equal(t, 0, len(wh.wlidsToContainerToImageIDMap))
 }
 
 //go:embed testdata/deployment-two-containers.json

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -23,7 +23,7 @@ import (
 
 func NewWatchHandlerMock() *WatchHandler {
 	return &WatchHandler{
-		iwMap:                             NewImageIDWLIDsMap(),
+		iwMap:                             NewImageHashWLIDsMap(),
 		wlidsToContainerToImageIDMap:      make(map[string]map[string]string),
 		wlidsToContainerToImageIDMapMutex: &sync.RWMutex{},
 		instanceIDsMutex:                  &sync.RWMutex{},
@@ -817,7 +817,7 @@ func TestAddTowlidsToContainerToImageIDMap(t *testing.T) {
 func TestGetNewImageIDsToContainerFromPod(t *testing.T) {
 	wh := NewWatchHandlerMock()
 
-	wh.iwMap = NewImageIDWLIDsMapFrom(map[string][]string{
+	wh.iwMap = NewImageHashWLIDsMapFrom(map[string][]string{
 		"alpine@sha256:1": {"wlid"},
 		"alpine@sha256:2": {"wlid"},
 		"alpine@sha256:3": {"wlid"},
@@ -921,7 +921,7 @@ func TestCleanUpWlidsToContainerToImageIDMap(t *testing.T) {
 
 func Test_cleanUpIDs(t *testing.T) {
 	wh := NewWatchHandlerMock()
-	wh.iwMap = NewImageIDWLIDsMapFrom(map[string][]string{
+	wh.iwMap = NewImageHashWLIDsMapFrom(map[string][]string{
 		"alpine@sha256:1": {"pod1"},
 		"alpine@sha256:2": {"pod2"},
 		"alpine@sha256:3": {"pod3"},

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -907,18 +907,6 @@ func TestGetNewImageIDsToContainerFromPod(t *testing.T) {
 	}
 }
 
-func TestCleanUpImagesIDToWlidsMap(t *testing.T) {
-	wh := NewWatchHandlerMock()
-	wh.iwMap = NewImageIDWLIDsMapFrom(map[string][]string{
-		"alpine@sha256:1": {"pod1"},
-		"alpine@sha256:2": {"pod2"},
-		"alpine@sha256:3": {"pod3"},
-	})
-	wh.cleanUpImagesIDToWlidsMap()
-
-	assert.Equal(t, 0, len(wh.iwMap.Map()))
-}
-
 func TestCleanUpWlidsToContainerToImageIDMap(t *testing.T) {
 	wh := NewWatchHandlerMock()
 	wh.wlidsToContainerToImageIDMap = map[string]map[string]string{


### PR DESCRIPTION
## Overview
Previously, the ImageID to WLIDs map used values that were sort of like Image IDs, but not really. This is problematic, since the map is supposed to be used as a way to look up entities that have Image Hashes as their keys.

When receiving such an entity, for example, an SBOM, our code cannot meaningfully transform the Image Hash of an SBOM, to an unambiguous, correct Image ID so we can look it up in the Image-WLID map.

Therefore, this map should use Image Hashes instead.

This PR refactors operations on the map to insert by Image Hash instead of Image IDs.

## Related issues/PRs:

This PR targets the relevancy branch, but requires that #93 is merged first. Check out that PR first.

* Requires #93

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes