### PR TITLE
fix: use hashed instance ID to check if a Filtered SBOM is recognized

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -773,6 +773,18 @@ func (wh *WatchHandler) handlePodWatcher(ctx context.Context, podsWatch watch.In
 			cmd = getImageScanCommand(parentWlid, containersToImageIds)
 		}
 
+		// generate instance IDs
+		instanceID, err := instanceidhandlerv1.GenerateInstanceIDFromPod(pod)
+		if err != nil {
+			logger.L().Ctx(ctx).Error("Failed to generate instance ID for pod", helpers.String("pod", pod.GetName()), helpers.String("namespace", pod.GetNamespace()), helpers.Error(err))
+			continue
+		}
+
+		// save on map
+		for i := range instanceID {
+			wh.addToInstanceIDsList(instanceID[i])
+		}
+
 		utils.AddCommandToChannel(ctx, cmd, sessionObjChan)
 	}
 }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -42,7 +42,7 @@ type WatchHandler struct {
 	k8sAPI                            *k8sinterface.KubernetesApi
 	storageClient                     kssc.Interface
 	iwMap                             *imageHashWLIDMap
-	instanceIDs                       []string
+	hashedInstanceIDs                 []string
 	instanceIDsMutex                  *sync.RWMutex
 	wlidsToContainerToImageIDMap      WlidsToContainerToImageIDMap // <wlid> : <containerName> : imageID
 	wlidsToContainerToImageIDMapMutex *sync.RWMutex
@@ -115,7 +115,7 @@ func NewWatchHandler(ctx context.Context, k8sAPI *k8sinterface.KubernetesApi, st
 		wlidsToContainerToImageIDMap:      make(WlidsToContainerToImageIDMap),
 		wlidsToContainerToImageIDMapMutex: &sync.RWMutex{},
 		instanceIDsMutex:                  &sync.RWMutex{},
-		instanceIDs:                       instanceIDs,
+		hashedInstanceIDs:                 instanceIDs,
 	}
 
 	// list all Pods and extract their image IDs
@@ -165,7 +165,7 @@ func (wh *WatchHandler) listInstanceIDs() []string {
 	wh.instanceIDsMutex.RLock()
 	defer wh.instanceIDsMutex.RUnlock()
 
-	return wh.instanceIDs
+	return wh.hashedInstanceIDs
 }
 
 // returns wlids map
@@ -293,12 +293,9 @@ func (wh *WatchHandler) HandleSBOMFilteredEvents(sfEvents <-chan watch.Event, er
 			continue
 		}
 
-		instanceID, err := labelsToInstanceID(obj.ObjectMeta.Annotations)
-		if err != nil {
-			errorCh <- ErrMissingInstanceIDAnnotation
-		}
+		hashedInstanceID := obj.ObjectMeta.Name
 
-		if !slices.Contains(wh.instanceIDs, instanceID) {
+		if !slices.Contains(wh.hashedInstanceIDs, hashedInstanceID) {
 			wh.storageClient.SpdxV1beta1().SBOMSPDXv2p3Filtereds(obj.ObjectMeta.Namespace).Delete(context.TODO(), obj.ObjectMeta.Name, v1.DeleteOptions{})
 		}
 	}
@@ -477,7 +474,7 @@ func (wh *WatchHandler) ListImageIDsFromStorage() ([]string, error) {
 
 func (wh *WatchHandler) cleanUpInstanceIDs() {
 	wh.instanceIDsMutex.Lock()
-	wh.instanceIDs = []string{}
+	wh.hashedInstanceIDs = []string{}
 	wh.instanceIDsMutex.Unlock()
 }
 
@@ -540,8 +537,8 @@ func (wh *WatchHandler) addToInstanceIDsList(instanceID instanceidhandler.IInsta
 	defer wh.instanceIDsMutex.Unlock()
 	h := instanceID.GetHashed()
 
-	if !slices.Contains(wh.instanceIDs, h) {
-		wh.instanceIDs = append(wh.instanceIDs, h)
+	if !slices.Contains(wh.hashedInstanceIDs, h) {
+		wh.hashedInstanceIDs = append(wh.hashedInstanceIDs, h)
 	}
 }
 

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -354,17 +354,14 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 		expectedErrors      []error
 	}{
 		{
-			name:        "Adding a new Filtered SBOM with an unknown instance ID should delete it from storage",
+			name:        "Adding a new Filtered SBOM with an unknown hashed instance ID should delete it from storage",
 			instanceIDs: []string{},
 			inputEvents: []watch.Event{
 				{
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "test-instance-id",
-							Annotations: map[string]string{
-								"instanceID": "apiVersion-v1/namespace-routing/kind-deployment/name-nginx-main-router/containerName-nginx",
-							},
+							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
 						},
 					},
 				},
@@ -374,21 +371,18 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 		},
 		{
 			name:        "Adding a new Filtered SBOM with known instance ID should keep it in storage",
-			instanceIDs: []string{"apiVersion-v1/namespace-routing/kind-deployment/name-nginx-main-router/containerName-nginx"},
+			instanceIDs: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 			inputEvents: []watch.Event{
 				{
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "test-instance-id",
-							Annotations: map[string]string{
-								"instanceID": "apiVersion-v1/namespace-routing/kind-deployment/name-nginx-main-router/containerName-nginx",
-							},
+							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
 						},
 					},
 				},
 			},
-			expectedObjectNames: []string{"test-instance-id"},
+			expectedObjectNames: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 			expectedErrors:      []error{},
 		},
 		{
@@ -399,32 +393,13 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Deleted,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "test-instance-id",
-							Annotations: map[string]string{
-								"instanceID": "apiVersion-v1/namespace-routing/kind-deployment/name-nginx-main-router/containerName-nginx",
-							},
+							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
 						},
 					},
 				},
 			},
-			expectedObjectNames: []string{"test-instance-id"},
+			expectedObjectNames: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 			expectedErrors:      []error{},
-		},
-		{
-			name:        "Adding a new Filtered SBOM with missing annotations should produce an error",
-			instanceIDs: []string{},
-			inputEvents: []watch.Event{
-				{
-					Type: watch.Added,
-					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
-						ObjectMeta: v1.ObjectMeta{
-							Name: "test-instance-id",
-						},
-					},
-				},
-			},
-			expectedObjectNames: []string{},
-			expectedErrors:      []error{ErrMissingInstanceIDAnnotation},
 		},
 		{
 			name:        "Adding an unsupported object should produce an error",
@@ -434,7 +409,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.VulnerabilityManifest{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "test-instance-id",
+							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
 						},
 					},
 				},
@@ -1141,16 +1116,16 @@ func Test_cleanUpIDs(t *testing.T) {
 		"pod2": {"container2": "alpine@sha256:2"},
 		"pod3": {"container3": "alpine@sha256:3"},
 	}
-	wh.instanceIDs = []string{
-		"apiVersion-v1/namespace-routing/kind-deployment/name-nginx-router-main/containerName-nginx",
-		"apiVersion-v1/namespace-routing/kind-deployment/name-nginx-router-failover/containerName-nginx",
-		"apiVersion-v1/namespace-webapp/kind-deployment/name-edge-server/containerName-webapp",
+	wh.hashedInstanceIDs = []string{
+		"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+		"f26b54ef2073feae80c40423a9fac44468ec4c655476ea8a57f601daa62240c2",
+		"8d39971275da811436922ae8d8f839827e5c6567738a1390bc94cfdb58bb8762",
 	}
 	wh.cleanUpIDs()
 
 	assert.Equal(t, 0, len(wh.iwMap.Map()))
 	assert.Equal(t, 0, len(wh.wlidsToContainerToImageIDMap))
-	assert.Equal(t, 0, len(wh.instanceIDs))
+	assert.Equal(t, 0, len(wh.hashedInstanceIDs))
 }
 
 //go:embed testdata/deployment-two-containers.json


### PR DESCRIPTION
## Overview

This change makes the WatchHandler use hashed instance IDs of the Filtered SBOMs it watches to check whether it recognizes them or not.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes