### PR TITLE
fix: look up Vulnerability Manifests by hashed instance IDs

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -262,12 +262,8 @@ func (wh *WatchHandler) HandleVulnerabilityManifestEvents(vmEvents <-chan watch.
 		var hasObject bool
 		if withRelevancy {
 			instanceIDs := wh.listInstanceIDs()
-			instanceID, err := labelsToInstanceID(obj.ObjectMeta.Annotations)
-			if err != nil {
-				errorCh <- err
-				return
-			}
-			hasObject = slices.Contains(instanceIDs, instanceID)
+			hashedInstanceID := manifestName
+			hasObject = slices.Contains(instanceIDs, hashedInstanceID)
 		} else {
 			_, hasObject = wh.iwMap.Load(imageHash)
 		}

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -136,7 +136,7 @@ func TestHandleVulnerabilityManifestEvents(t *testing.T) {
 			imageWLIDsMap: map[string][]string{
 				"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824": {"wlid://some-wlid"},
 			},
-			instanceIDs: []string{"apiVersion-v1/namespace-routing/kind-deployment/name-nginx-main-router/containerName-nginx"},
+			instanceIDs: []string{"486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7"},
 			inputEvents: []watch.Event{
 				// Known no-relevancy VM
 				{
@@ -158,9 +158,6 @@ func TestHandleVulnerabilityManifestEvents(t *testing.T) {
 					Object: &spdxv1beta1.VulnerabilityManifest{
 						ObjectMeta: v1.ObjectMeta{
 							Name: "486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7",
-							Annotations: map[string]string{
-								"instanceID": "apiVersion-v1/namespace-routing/kind-deployment/name-nginx-main-router/containerName-nginx",
-							},
 						},
 						Spec: spdxv1beta1.VulnerabilityManifestSpec{
 							Metadata: spdxv1beta1.VulnerabilityManifestMeta{
@@ -251,36 +248,6 @@ func TestHandleVulnerabilityManifestEvents(t *testing.T) {
 			},
 			expectedObjectNames: []string{},
 			expectedErrors:      []error{ErrUnsupportedObject},
-		},
-		{
-			name:          "Adding Vulnerability Manifests with no instance ID should produce a matching error",
-			imageWLIDsMap: map[string][]string{},
-			instanceIDs:   []string{},
-			inputEvents: []watch.Event{
-				{
-					Type: watch.Added,
-					Object: &spdxv1beta1.VulnerabilityManifest{
-						ObjectMeta: v1.ObjectMeta{
-							Name:        "22c72aa82ce77c82e2ca65a711c79eaa4b51c57f85f91489ceeacc7b385943ba",
-							Annotations: map[string]string{
-								// Expected Annotation empty
-							},
-						},
-						Spec: spdxv1beta1.VulnerabilityManifestSpec{
-							Metadata: spdxv1beta1.VulnerabilityManifestMeta{
-								WithRelevancy: true,
-							},
-						},
-					},
-				},
-			},
-			// Since in the beginning of the test we add all objects from the
-			// input events to the storage, and we expect to produce an error
-			// without taking actions, the object should stay in the storage
-			expectedObjectNames: []string{
-				"22c72aa82ce77c82e2ca65a711c79eaa4b51c57f85f91489ceeacc7b385943ba",
-			},
-			expectedErrors: []error{ErrMissingInstanceIDAnnotation},
 		},
 	}
 


### PR DESCRIPTION
## Overview

Since we store hashed instance IDs in the list of instance IDs we manage, we also need to look them up by hashed instance IDs. This fix makes the Watch Handler look up Vulnerability Manifests by hashed instance IDs, instead of the plain ones.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes