### PR TITLE
dont scan cronjobs && fix nil pointer

### DIFF
--- a/mainhandler/getworkload.go
+++ b/mainhandler/getworkload.go
@@ -27,15 +27,17 @@ func listWorkloadImages(workload k8sinterface.IWorkload, instanceIDs []instancei
 		id := getContainerID(instanceIDs, containers[i].Name)
 		if id != nil {
 			c = id.GetHashed()
+			containersData = append(containersData,
+				ContainerData{
+					image:     containers[i].Image,
+					container: containers[i].Name,
+					id:        c,
+				},
+			)
+			logger.L().Debug("instanceID", helpers.String("str", id.GetStringFormatted()), helpers.String("id", id.GetHashed()), helpers.String("workloadID", workload.GetID()), helpers.String("container", containers[i].Name), helpers.String("image", containers[i].Image))
+		} else {
+			logger.L().Debug("instance id is nil, skipping", helpers.String("workloadID", workload.GetID()), helpers.String("container", containers[i].Name), helpers.String("image", containers[i].Image))
 		}
-		containersData = append(containersData,
-			ContainerData{
-				image:     containers[i].Image,
-				container: containers[i].Name,
-				id:        c,
-			},
-		)
-		logger.L().Debug("instanceID", helpers.String("str", id.GetStringFormatted()), helpers.String("id", id.GetHashed()), helpers.String("workloadID", workload.GetID()), helpers.String("container", containers[i].Name), helpers.String("image", containers[i].Image))
 	}
 	initContainers, err := workload.GetInitContainers()
 	if err != nil {

--- a/mainhandler/getworkload.go
+++ b/mainhandler/getworkload.go
@@ -36,7 +36,7 @@ func listWorkloadImages(workload k8sinterface.IWorkload, instanceIDs []instancei
 			)
 			logger.L().Debug("instanceID", helpers.String("str", id.GetStringFormatted()), helpers.String("id", id.GetHashed()), helpers.String("workloadID", workload.GetID()), helpers.String("container", containers[i].Name), helpers.String("image", containers[i].Image))
 		} else {
-			logger.L().Debug("instance id is nil, skipping", helpers.String("workloadID", workload.GetID()), helpers.String("container", containers[i].Name), helpers.String("image", containers[i].Image))
+			logger.L().Debug("instanceID is nil, skipping", helpers.String("workloadID", workload.GetID()), helpers.String("container", containers[i].Name), helpers.String("image", containers[i].Image))
 		}
 	}
 	initContainers, err := workload.GetInitContainers()

--- a/mainhandler/handlerequestsutils.go
+++ b/mainhandler/handlerequestsutils.go
@@ -43,6 +43,12 @@ func (mainHandler *MainHandler) getResourcesIDs(workloads []k8sinterface.IWorklo
 			if err != nil {
 				errs = append(errs, fmt.Errorf("CalculateWorkloadParentRecursive: namespace: %s, pod name: %s, error: %s", workloads[i].GetNamespace(), workloads[i].GetName(), err.Error()))
 			}
+
+			// skip cronjobs
+			if kind == "CronJob" {
+				continue
+			}
+
 			wlid := pkgwlid.GetWLID(utils.ClusterConfig.ClusterName, workloads[i].GetNamespace(), kind, name)
 			if wlid != "" {
 				idMap[wlid] = true

--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -293,6 +293,11 @@ func (actionHandler *ActionHandler) scanWorkload(ctx context.Context, sessionObj
 		return fmt.Errorf("failed to get workload %s with err %v", actionHandler.wlid, err)
 	}
 
+	if workload.GetKind() == "CronJob" {
+		logger.L().Ctx(ctx).Debug("workload is CronJob, skipping")
+		return nil
+	}
+
 	pod, err := actionHandler.getPodByWLID(workload)
 	if err != nil {
 		err = fmt.Errorf("failed to get container to image ID map for workload %s with err %v", actionHandler.wlid, err)


### PR DESCRIPTION
## Overview
<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->
Operator was crashing because of a nil pointer access. This was done when logging properties of the instanceID, which was nil. 
After a deeper look, the conclusion is that the instanceID being generated is incorrect, due to the fact that we cannot find Pods which belong to a CronJob in a top-down approach. 
This PR:
1 - Fixes the nil pointer access
2 - Don't send command to scan CronJobs when generating commands for a namespace scan
3 - In case a command was given to scan a CronJob, it will be skipped

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 