### PR TITLE
fix(watcher): look for SBOMFiltered instanceIDs in the annotations

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -27,8 +27,6 @@ import (
 
 const (
 	retryInterval = 3 * time.Second
-
-	instanceIDAnnotationKey = "instanceID"
 )
 
 var (
@@ -119,7 +117,7 @@ func (wh *WatchHandler) GetWlidsToContainerToImageIDMap() WlidsToContainerToImag
 }
 
 func labelsToInstanceID(labels map[string]string) (string, error) {
-	instanceID, ok := labels[instanceIDAnnotationKey]
+	instanceID, ok := labels[instanceidhandlerv1.InstanceIDMetadataKey]
 	if !ok {
 		return instanceID, ErrMissingInstanceIDAnnotation
 	}
@@ -231,7 +229,11 @@ func (wh *WatchHandler) HandleSBOMFilteredEvents(sfEvents <-chan watch.Event, pr
 			continue
 		}
 
-		hashedInstanceID := obj.ObjectMeta.Name
+		hashedInstanceID, err := labelsToInstanceID(obj.ObjectMeta.Annotations)
+		if err != nil {
+			errorCh <- ErrMissingInstanceIDAnnotation
+			continue
+		}
 
 		if !slices.Contains(wh.hashedInstanceIDs, hashedInstanceID) {
 			wh.storageClient.SpdxV1beta1().SBOMSPDXv2p3Filtereds(obj.ObjectMeta.Namespace).Delete(context.TODO(), obj.ObjectMeta.Name, v1.DeleteOptions{})

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -331,7 +331,10 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+							Name: "default-pod-reverse-proxy-1ba5-4aaf",
+							Annotations: map[string]string{
+								instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+							},
 						},
 					},
 				},
@@ -353,15 +356,16 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+							Name: "default-pod-reverse-proxy-1ba5-4aaf",
 							Annotations: map[string]string{
-								instanceidv1.WlidMetadataKey: "wlid://cluster-relevant-clutser/namespace-routing/deployment-nginx",
+								instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+								instanceidv1.WlidMetadataKey:       "wlid://cluster-relevant-clutser/namespace-routing/deployment-nginx",
 							},
 						},
 					},
 				},
 			},
-			expectedObjectNames: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
+			expectedObjectNames: []string{"default-pod-reverse-proxy-1ba5-4aaf"},
 			expectedCommands: []*apis.Command{
 				{
 					CommandName: apis.TypeScanImages,
@@ -376,7 +380,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 			expectedErrors: []error{},
 		},
 		{
-			name:        "Adding a new Filtered SBOM with known instance ID but missing annotation should produce a matching error",
+			name:        "Adding a new Filtered SBOM with known instance ID but missing WLID annotation should produce a matching error",
 			instanceIDs: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 			wlidsToContainersToImageIDsMap: WlidsToContainerToImageIDMap{
 				"wlid://cluster-relevant-clutser/namespace-routing/deployment-nginx": {
@@ -388,15 +392,40 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name:        "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
-							Annotations: map[string]string{},
+							Name:        "default-pod-reverse-proxy-1ba5-4aaf",
+							Annotations: map[string]string{instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 						},
 					},
 				},
 			},
-			expectedObjectNames: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
+			expectedObjectNames: []string{"default-pod-reverse-proxy-1ba5-4aaf"},
 			expectedCommands:    []*apis.Command{},
 			expectedErrors:      []error{ErrMissingWLIDAnnotation},
+		},
+		{
+			name:        "Adding a new Filtered SBOM with missing InstanceID annotation should produce a matching error",
+			instanceIDs: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
+			wlidsToContainersToImageIDsMap: WlidsToContainerToImageIDMap{
+				"wlid://cluster-relevant-clutser/namespace-routing/deployment-nginx": {
+					"nginx": "nginx@sha256:1f4e3b6489888647ce1834b601c6c06b9f8c03dee6e097e13ed3e28c01ea3ac8c",
+				},
+			},
+			inputEvents: []watch.Event{
+				{
+					Type: watch.Added,
+					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "default-pod-reverse-proxy-1ba5-4aaf",
+							Annotations: map[string]string{
+								instanceidv1.WlidMetadataKey: "wlid://cluster-relevant-clutser/namespace-routing/deployment-nginx",
+							},
+						},
+					},
+				},
+			},
+			expectedObjectNames: []string{"default-pod-reverse-proxy-1ba5-4aaf"},
+			expectedCommands:    []*apis.Command{},
+			expectedErrors:      []error{ErrMissingInstanceIDAnnotation},
 		},
 		{
 			name:        "Deleting a Filtered SBOM should be ignored",
@@ -406,12 +435,13 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Deleted,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+							Name:        "default-pod-reverse-proxy-1ba5-4aaf",
+							Annotations: map[string]string{instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 						},
 					},
 				},
 			},
-			expectedObjectNames: []string{"60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
+			expectedObjectNames: []string{"default-pod-reverse-proxy-1ba5-4aaf"},
 			expectedCommands:    []*apis.Command{},
 			expectedErrors:      []error{},
 		},
@@ -423,7 +453,8 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.VulnerabilityManifest{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c",
+							Name:        "default-pod-reverse-proxy-1ba5-4aaf",
+							Annotations: map[string]string{instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 						},
 					},
 				},


### PR DESCRIPTION

## Overview
Previously the watcher assumed that the instance ID of a FitleredSBOM would be stored in the resource name. Now, as the naming scheme changed, the watcher relies on having it in the annotations.

## Additional Information
Ideally, fetching the instance ID should be available from either our custom types via a dedicated method, e.g `SBOMSPDXv2p3Filtered.InstanceID()` or extracted to the `k8s-interface` package. But doing this is faster.

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes
 