### PR TITLE
core(scan): Replace channel with pool

### DIFF
--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 // CreateWebSocketHandler Create ws-handler obj
-func NewMainHandler(sessionObj *chan utils.SessionObj, k8sAPI *k8sinterface.KubernetesApi) *MainHandler {
+func NewMainHandler(k8sAPI *k8sinterface.KubernetesApi) *MainHandler {
 
 	commandResponseChannel := make(chan *CommandResponseData, 100)
 	limitedGoRoutinesCommandResponseChannel := make(chan *timerData, 10)
@@ -350,6 +350,10 @@ func (mainHandler *MainHandler) StartupTriggerActions(ctx context.Context, actio
 			}
 		}(i)
 	}
+}
+
+func (mainHandler *MainHandler) EventWorkerPool() *ants.PoolWithFunc {
+	return mainHandler.eventWorkerPool
 }
 
 func GetStartupActions() []apis.Command {

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -346,7 +346,7 @@ func (mainHandler *MainHandler) StartupTriggerActions(ctx context.Context, actio
 			l.SetContext(ctx)
 			l.SetObj(*sessionObj)
 			if err := mainHandler.eventWorkerPool.Invoke(l); err != nil {
-				logger.L().Ctx(ctx).Error("Failed to invoke job", helpers.String("wlid", actions[index].GetID()), helpers.String("command", fmt.Sprintf("%v", actions[index].CommandName)), helpers.String("args", fmt.Sprintf("%v", actions[index].Args)), helpers.Error(err))
+				logger.L().Ctx(ctx).Error("failed to invoke job", helpers.String("wlid", actions[index].GetID()), helpers.String("command", fmt.Sprintf("%v", actions[index].CommandName)), helpers.String("args", fmt.Sprintf("%v", actions[index].Args)), helpers.Error(err))
 			}
 		}(i)
 	}

--- a/notificationhandler/websocket.go
+++ b/notificationhandler/websocket.go
@@ -8,22 +8,23 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/operator/utils"
+	"github.com/panjf2000/ants/v2"
 
 	"github.com/armosec/cluster-notifier-api-go/notificationserver"
 	"github.com/gorilla/websocket"
 )
 
 type NotificationHandler struct {
-	connector  IWebsocketActions
-	sessionObj *chan utils.SessionObj
+	connector IWebsocketActions
+	pool      *ants.PoolWithFunc
 }
 
-func NewNotificationHandler(sessionObj *chan utils.SessionObj) *NotificationHandler {
+func NewNotificationHandler(pool *ants.PoolWithFunc) *NotificationHandler {
 	urlStr := initNotificationServerURL()
 
 	return &NotificationHandler{
-		connector:  NewWebsocketActions(urlStr),
-		sessionObj: sessionObj,
+		connector: NewWebsocketActions(urlStr),
+		pool:      pool,
 	}
 }
 

--- a/notificationhandler/websocket_test.go
+++ b/notificationhandler/websocket_test.go
@@ -4,12 +4,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/kubescape/operator/utils"
+	"github.com/panjf2000/ants/v2"
 )
 
 func TestNewTriggerHandlerNotificationHandler(t *testing.T) {
 	type args struct {
-		sessionObj *chan utils.SessionObj
+		pool *ants.PoolWithFunc
 	}
 	tests := []struct {
 		name string
@@ -20,7 +20,7 @@ func TestNewTriggerHandlerNotificationHandler(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewNotificationHandler(tt.args.sessionObj); !reflect.DeepEqual(got, tt.want) {
+			if got := NewNotificationHandler(tt.args.pool); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("NewTriggerHandlerNotificationHandler() = %v, want %v", got, tt.want)
 			}
 		})

--- a/notificationhandler/websocketutils.go
+++ b/notificationhandler/websocketutils.go
@@ -46,7 +46,7 @@ func (notification *NotificationHandler) handleNotification(ctx context.Context,
 		}
 		for _, cmd := range cmds.Commands {
 			sessionObj := utils.NewSessionObj(ctx, &cmd, "WebSocket", cmd.JobTracking.ParentID, cmd.JobTracking.JobID, 1)
-			*notification.sessionObj <- *sessionObj
+			notification.pool.Invoke(sessionObj)
 		}
 	}
 

--- a/notificationhandler/websocketutils.go
+++ b/notificationhandler/websocketutils.go
@@ -46,7 +46,9 @@ func (notification *NotificationHandler) handleNotification(ctx context.Context,
 		}
 		for _, cmd := range cmds.Commands {
 			sessionObj := utils.NewSessionObj(ctx, &cmd, "WebSocket", cmd.JobTracking.ParentID, cmd.JobTracking.JobID, 1)
-			notification.pool.Invoke(sessionObj)
+			if err := notification.pool.Invoke(sessionObj); err != nil {
+				logger.L().Ctx(ctx).Error("failed to invoke job", helpers.String("ID", cmd.GetID()), helpers.String("command", fmt.Sprintf("%v", cmd)), helpers.Error(err))
+			}
 		}
 	}
 

--- a/restapihandler/restapi.go
+++ b/restapihandler/restapi.go
@@ -8,20 +8,21 @@ import (
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/operator/docs"
 	"github.com/kubescape/operator/utils"
+	"github.com/panjf2000/ants/v2"
 
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux"
 )
 
 type HTTPHandler struct {
-	keyPair    *tls.Certificate
-	sessionObj *chan utils.SessionObj
+	keyPair *tls.Certificate
+	pool    *ants.PoolWithFunc
 }
 
-func NewHTTPHandler(sessionObj *chan utils.SessionObj) *HTTPHandler {
+func NewHTTPHandler(pool *ants.PoolWithFunc) *HTTPHandler {
 	return &HTTPHandler{
-		keyPair:    nil,
-		sessionObj: sessionObj,
+		keyPair: nil,
+		pool:    pool,
 	}
 }
 

--- a/restapihandler/triggeraction.go
+++ b/restapihandler/triggeraction.go
@@ -52,7 +52,9 @@ func (resthandler *HTTPHandler) HandleActionRequest(ctx context.Context, receive
 			continue
 		}
 
-		resthandler.pool.Invoke(sessionObj)
+		if err := resthandler.pool.Invoke(sessionObj); err != nil {
+			logger.L().Ctx(ctx).Error("failed to invoke job", helpers.String("ID", c.GetID()), helpers.Error(err))
+		}
 	}
 	return nil
 }

--- a/restapihandler/triggeraction.go
+++ b/restapihandler/triggeraction.go
@@ -52,7 +52,7 @@ func (resthandler *HTTPHandler) HandleActionRequest(ctx context.Context, receive
 			continue
 		}
 
-		*resthandler.sessionObj <- *sessionObj
+		resthandler.pool.Invoke(sessionObj)
 	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -69,7 +69,7 @@ func AddCommandToChannel(ctx context.Context, cmd *apis.Command, workerPool *ant
 	logger.L().Ctx(ctx).Info("Triggering scan for", helpers.String("wlid", cmd.Wlid), helpers.String("command", fmt.Sprintf("%v", cmd.CommandName)), helpers.String("args", fmt.Sprintf("%v", cmd.Args)))
 	newSessionObj := NewSessionObj(ctx, cmd, "Websocket", "", uuid.NewString(), 1)
 	if err := workerPool.Invoke(Job{ctx: ctx, sessionObj: *newSessionObj}); err != nil {
-		logger.L().Ctx(ctx).Error("Failed to invoke job", helpers.String("wlid", cmd.Wlid), helpers.String("command", fmt.Sprintf("%v", cmd.CommandName)), helpers.String("args", fmt.Sprintf("%v", cmd.Args)), helpers.Error(err))
+		logger.L().Ctx(ctx).Error("failed to invoke job", helpers.String("wlid", cmd.Wlid), helpers.String("command", fmt.Sprintf("%v", cmd.CommandName)), helpers.String("args", fmt.Sprintf("%v", cmd.Args)), helpers.Error(err))
 	}
 }
 


### PR DESCRIPTION
## Overview
In this PR I replaced the notification and REST API handling so the command will be invoked by the pool and not channel 
This PR fixes #

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [ ] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 