### PR TITLE
don't check for accountID without service discovery

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,13 +123,6 @@ func LoadClusterConfig() (utilsmetadata.ClusterConfig, error) {
 		return utilsmetadata.ClusterConfig{}, err
 	}
 
-	if clusterConfig.ClusterName == "" {
-		return utilsmetadata.ClusterConfig{}, fmt.Errorf("missing cluster name in config")
-	}
-	if clusterConfig.AccountID == "" {
-		return utilsmetadata.ClusterConfig{}, fmt.Errorf("missing customer guid in config")
-	}
-
 	return *clusterConfig, err
 }
 
@@ -143,4 +136,14 @@ func GetServiceURLs(filePath string) (schema.IBackendServices, error) {
 	return servicediscovery.GetServices(
 		v1.NewServiceDiscoveryFileV1(pathAndFileName),
 	)
+}
+
+func ValidateConfig(clusterConfig utilsmetadata.ClusterConfig, components CapabilitiesConfig) error {
+	if clusterConfig.AccountID == "" && components.Components.ServiceDiscovery.Enabled {
+		return fmt.Errorf("missing customer guid in config")
+	}
+	if clusterConfig.ClusterName == "" {
+		return fmt.Errorf("missing cluster name in config")
+	}
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/armosec/utils-k8s-go/armometadata"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -101,6 +102,79 @@ func TestLoadConfig(t *testing.T) {
 				return
 			}
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	type args struct {
+		clusterConfig armometadata.ClusterConfig
+		components    CapabilitiesConfig
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "no clusterName: error",
+			args: args{
+				clusterConfig: armometadata.ClusterConfig{},
+				components:    CapabilitiesConfig{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no discovery, no account: error",
+			args: args{
+				clusterConfig: armometadata.ClusterConfig{
+					ClusterName: "foo",
+				},
+				components: CapabilitiesConfig{},
+			},
+		},
+		{
+			name: "discovery, no account: error",
+			args: args{
+				clusterConfig: armometadata.ClusterConfig{
+					ClusterName: "foo",
+				},
+				components: CapabilitiesConfig{
+					Components: Components{ServiceDiscovery: Component{Enabled: true}},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no discovery, account: no error",
+			args: args{
+				clusterConfig: armometadata.ClusterConfig{
+					AccountID:   "123",
+					ClusterName: "foo",
+				},
+				components: CapabilitiesConfig{},
+			},
+		},
+		{
+			name: "discovery, account: no error",
+			args: args{
+				clusterConfig: armometadata.ClusterConfig{
+					AccountID:   "123",
+					ClusterName: "foo",
+				},
+				components: CapabilitiesConfig{
+					Components: Components{ServiceDiscovery: Component{Enabled: true}},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateConfig(tt.args.clusterConfig, tt.args.components)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -43,6 +43,8 @@ func main() {
 	}
 	logger.L().Debug("loaded config for components", helpers.Interface("components", components))
 
+	config.ValidateConfig(clusterConfig, components)
+
 	var eventReceiverRestURL string
 	if components.Components.ServiceDiscovery.Enabled {
 		services, err := config.GetServiceURLs("/etc/config/services.json")


### PR DESCRIPTION
## PR Type:
Refactoring

___
## PR Description:
This PR modifies the configuration validation logic to only check for the presence of an AccountID when the Service Discovery feature is enabled. This change is reflected in both the main application logic and the associated tests.

___
## PR Main Files Walkthrough:
`config/config.go`: Removed the check for AccountID from the LoadClusterConfig function. Introduced a new function ValidateConfig that checks for AccountID only if Service Discovery is enabled.
`config/config_test.go`: Added a new test function TestValidateConfig to test the new ValidateConfig function under various scenarios.
`main.go`: Added a call to the new ValidateConfig function to validate the configuration during the application startup.
