### PR TITLE
Bug fixes

### DIFF
--- a/mainhandler/kubescapehandlerhelper.go
+++ b/mainhandler/kubescapehandlerhelper.go
@@ -67,10 +67,18 @@ func getKubescapeV1ScanRequest(args map[string]interface{}) (*utilsmetav1.PostSc
 		return nil, err
 	}
 
-	// validate
 	postScanRequest := &utilsmetav1.PostScanRequest{}
 	if err := json.Unmarshal(scanV1Bytes, postScanRequest); err != nil {
 		return nil, fmt.Errorf("failed to convert request to v1/scan object, reason: %s", err.Error())
+	}
+	if len(postScanRequest.TargetNames) == 0 || postScanRequest.TargetType == "" {
+		setDefaultsKubescapeScanRequest(postScanRequest)
+	}
+
+	for i := range postScanRequest.TargetNames {
+		if postScanRequest.TargetNames[i] == "" {
+			postScanRequest.TargetNames[i] = "all"
+		}
 	}
 
 	return postScanRequest, nil
@@ -222,7 +230,7 @@ func setDefaultsKubescapeScanRequest(postScanRequest *utilsmetav1.PostScanReques
 // appendSecurityFramework - append "security" framework to the request if targetType is "Framework"
 func appendSecurityFramework(postScanRequest *utilsmetav1.PostScanRequest) {
 	if postScanRequest.TargetType == utilsapisv1.KindFramework {
-		if !slices.Contains(postScanRequest.TargetNames, "all") && !slices.Contains(postScanRequest.TargetNames, securityFrameworkName) {
+		if !slices.Contains(postScanRequest.TargetNames, securityFrameworkName) {
 			postScanRequest.TargetNames = append(postScanRequest.TargetNames, securityFrameworkName)
 		}
 	}

--- a/mainhandler/kubescapehandlerhelper_test.go
+++ b/mainhandler/kubescapehandlerhelper_test.go
@@ -1,18 +1,17 @@
 package mainhandler
 
 import (
+	"fmt"
 	"testing"
 
-	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
-	"github.com/kubescape/operator/utils"
-
+	"github.com/armosec/armoapi-go/apis"
 	"github.com/armosec/utils-go/boolutils"
+	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
 	utilsapisv1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
 	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	"github.com/kubescape/operator/utils"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/batch/v1"
-
-	"github.com/armosec/armoapi-go/apis"
 )
 
 func TestGetKubescapeV1ScanRequest(t *testing.T) {
@@ -35,6 +34,24 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 		req, err := getKubescapeV1ScanRequest(actionHandler.command.Args)
 		assert.NoError(t, err)
 		assert.Equal(t, "json", req.Format)
+	}
+	{
+		actionHandler := ActionHandler{
+			command: apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{}}},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.command.Args)
+		assert.NoError(t, err)
+		assert.Equal(t, "all", req.TargetNames[0])
+		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
+	}
+	{
+		actionHandler := ActionHandler{
+			command: apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{"targetType": utilsapisv1.KindFramework, "targetNames": []string{""}}}},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.command.Args)
+		assert.NoError(t, err)
+		assert.Equal(t, "all", req.TargetNames[0])
+		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
 	}
 }
 
@@ -117,4 +134,50 @@ func TestAppendSecurityFramework(t *testing.T) {
 		})
 	}
 
+}
+
+func Test_appendSecurityFramework(t *testing.T) {
+	type args struct {
+		postScanRequest *utilsmetav1.PostScanRequest
+	}
+	tests := []struct {
+		args     args
+		name     string
+		expected []string
+	}{
+		{
+			name: "framework scan with one framework ",
+			args: args{
+				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"nsa"}},
+			},
+			expected: []string{"nsa", "security"},
+		},
+		{
+			name: "framework scan with all",
+			args: args{
+				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"all"}},
+			},
+			expected: []string{"all", "security"},
+		},
+		{
+			name: "framework scan with security",
+			args: args{
+				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"security"}},
+			},
+			expected: []string{"security"},
+		},
+		{
+			name: "not framework scan",
+			args: args{
+				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindControl, TargetNames: []string{"c-0001"}},
+			},
+			expected: []string{"c-0001"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appendSecurityFramework(tt.args.postScanRequest)
+			assert.Equal(t, fmt.Sprint(tt.args.postScanRequest.TargetNames), fmt.Sprint(tt.expected))
+		})
+	}
 }

--- a/mainhandler/kubescapehandlerhelper_test.go
+++ b/mainhandler/kubescapehandlerhelper_test.go
@@ -1,7 +1,6 @@
 package mainhandler
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -113,7 +112,7 @@ func TestAppendSecurityFramework(t *testing.T) {
 		{
 			name:            "framework scan with all",
 			postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"all"}},
-			expected:        &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"all"}},
+			expected:        &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"all", "security"}},
 		},
 		{
 			name:            "framework scan with security",
@@ -134,50 +133,4 @@ func TestAppendSecurityFramework(t *testing.T) {
 		})
 	}
 
-}
-
-func Test_appendSecurityFramework(t *testing.T) {
-	type args struct {
-		postScanRequest *utilsmetav1.PostScanRequest
-	}
-	tests := []struct {
-		args     args
-		name     string
-		expected []string
-	}{
-		{
-			name: "framework scan with one framework ",
-			args: args{
-				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"nsa"}},
-			},
-			expected: []string{"nsa", "security"},
-		},
-		{
-			name: "framework scan with all",
-			args: args{
-				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"all"}},
-			},
-			expected: []string{"all", "security"},
-		},
-		{
-			name: "framework scan with security",
-			args: args{
-				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindFramework, TargetNames: []string{"security"}},
-			},
-			expected: []string{"security"},
-		},
-		{
-			name: "not framework scan",
-			args: args{
-				postScanRequest: &utilsmetav1.PostScanRequest{TargetType: utilsapisv1.KindControl, TargetNames: []string{"c-0001"}},
-			},
-			expected: []string{"c-0001"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			appendSecurityFramework(tt.args.postScanRequest)
-			assert.Equal(t, fmt.Sprint(tt.args.postScanRequest.TargetNames), fmt.Sprint(tt.expected))
-		})
-	}
 }


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR introduces two main changes. Firstly, it fixes the issue where the security framework was not being added when the request body was empty. Secondly, it modifies the pod selection mechanism to trigger image scan based on the latest created pod instead of the first one in the list. Some redundant tests have also been removed.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`mainhandler/kubescapehandlerhelper.go`: The security framework is now added even when the request body is empty. Default values are set for KubescapeScanRequest when TargetNames is empty or TargetType is not provided. The security framework is appended to the request if the targetType is "Framework".
`mainhandler/kubescapehandlerhelper_test.go`: Tests have been updated to reflect the changes in the mainhandler/kubescapehandlerhelper.go file. Some redundant tests have been removed.
`mainhandler/vulnscan.go`: The pod selection mechanism has been updated. Now, the image scan is triggered based on the latest created pod instead of the first one in the list.
</details>

___
## User Description:
## Overview
* Fix: The security framework will be added also when the request body is empty
* Fix: Image scan will trigger based on the latest pod created and not the first index in the list 


**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [ ] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
