### PR TITLE
Added request headers to GetRegistryRepositoriesUrl

### DIFF
--- a/mainhandler/imageregistryhandler.go
+++ b/mainhandler/imageregistryhandler.go
@@ -849,6 +849,10 @@ func (registryScan *registryScan) SendRepositoriesAndTags(params RepositoriesAnd
 	if err != nil {
 		return fmt.Errorf("in 'SendRepositoriesAndTags' failed to create request, reason: %v", err)
 	}
+	for k, v := range utils.GetRequestHeaders(registryScan.config.AccessKey()) {
+		req.Header.Set(k, v)
+	}
+
 	_, err = http.DefaultClient.Do(req)
 
 	if err != nil {

--- a/utils/typesutils.go
+++ b/utils/typesutils.go
@@ -19,7 +19,7 @@ var (
 	ReporterHttpClient httputils.IHttpClient
 )
 
-func getRequestHeaders(accessKey string) map[string]string {
+func GetRequestHeaders(accessKey string) map[string]string {
 	return map[string]string{
 		"Content-Type":             "application/json",
 		beServerV1.AccessKeyHeader: accessKey,
@@ -51,7 +51,7 @@ func NewSessionObj(ctx context.Context, config config.IConfig, command *apis.Com
 			report.SetActionName(string(command.CommandName))
 		}
 
-		noHeaders := getRequestHeaders(config.AccessKey())
+		noHeaders := GetRequestHeaders(config.AccessKey())
 		reporter = beClientV1.NewBaseReportSender(config.EventReceiverURL(), ReporterHttpClient, noHeaders, report)
 	}
 


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This pull request includes changes to add request headers to the `GetRegistryRepositoriesUrl` function. The changes include:
- Adding a loop to set headers from the `GetRequestHeaders` function in the `SendRepositoriesAndTags` function.
- Changing the `getRequestHeaders` function to `GetRequestHeaders` to make it public.
- Updating the function call in `NewSessionObj` to use the new function name.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`mainhandler/imageregistryhandler.go`: Added a loop to set headers from the `GetRequestHeaders` function in the `SendRepositoriesAndTags` function.
`utils/typesutils.go`: Changed the `getRequestHeaders` function to `GetRequestHeaders` to make it public and updated the function call in `NewSessionObj` to use the new function name.
</details>

___
## User Description:
## Overview
This PR fixes #

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
