### PR TITLE
Get namespace name from config

### DIFF
--- a/mainhandler/imageregistryhandler.go
+++ b/mainhandler/imageregistryhandler.go
@@ -273,7 +273,7 @@ func (registryScan *registryScan) createTriggerRequestSecret(k8sAPI *k8sinterfac
 	}
 
 	secret.StringData[registriesAuthFieldInSecret] = string(registryAuthBytes)
-	if _, err := k8sAPI.KubernetesClient.CoreV1().Secrets(armotypes.KubescapeNamespace).Create(context.Background(), &secret, metav1.CreateOptions{}); err != nil {
+	if _, err := k8sAPI.KubernetesClient.CoreV1().Secrets(registryScan.config.Namespace()).Create(context.Background(), &secret, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	registryScan.registryInfo.SecretName = name
@@ -301,7 +301,7 @@ func (registryScan *registryScan) createTriggerRequestConfigMap(k8sAPI *k8sinter
 	// command will be mounted into cronjob by using this configmap
 	configMap.Data[requestBodyFile] = string(command)
 
-	if _, err := k8sAPI.KubernetesClient.CoreV1().ConfigMaps(armotypes.KubescapeNamespace).Create(context.Background(), &configMap, metav1.CreateOptions{}); err != nil {
+	if _, err := k8sAPI.KubernetesClient.CoreV1().ConfigMaps(registryScan.config.Namespace()).Create(context.Background(), &configMap, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -652,7 +652,7 @@ func (registryScan *registryScan) parseRegistry(ctx context.Context, sessionObj 
 func (registryScan *registryScan) createTriggerRequestCronJob(k8sAPI *k8sinterface.KubernetesApi, name, registryName string, command apis.Command) error {
 
 	// cronjob template is stored as configmap in cluster
-	jobTemplateObj, err := getCronJobTemplate(k8sAPI, registryCronjobTemplate, armotypes.KubescapeNamespace)
+	jobTemplateObj, err := getCronJobTemplate(k8sAPI, registryCronjobTemplate, registryScan.config.Namespace())
 	if err != nil {
 		return err
 	}
@@ -663,7 +663,7 @@ func (registryScan *registryScan) createTriggerRequestCronJob(k8sAPI *k8sinterfa
 	}
 
 	// create cronJob
-	if _, err := k8sAPI.KubernetesClient.BatchV1().CronJobs(armotypes.KubescapeNamespace).Create(context.Background(), jobTemplateObj, metav1.CreateOptions{}); err != nil {
+	if _, err := k8sAPI.KubernetesClient.BatchV1().CronJobs(registryScan.config.Namespace()).Create(context.Background(), jobTemplateObj, metav1.CreateOptions{}); err != nil {
 		return err
 	}
 	return nil
@@ -681,7 +681,7 @@ func (registryScan *registryScan) setRegistryAuthFromSecret(ctx context.Context)
 	}
 
 	// find secret in cluster
-	secrets, err := getRegistryScanSecrets(registryScan.k8sAPI, secretName)
+	secrets, err := getRegistryScanSecrets(registryScan.k8sAPI, registryScan.config.Namespace(), secretName)
 	if err != nil || len(secrets) == 0 {
 		return err
 	}
@@ -754,7 +754,7 @@ func (registryScan *registryScan) setRegistryInfoFromAuth(auth registryAuth, reg
 }
 
 func (registryScan *registryScan) getRegistryConfig(registryInfo *armotypes.RegistryInfo) (string, error) {
-	configMap, err := registryScan.k8sAPI.GetWorkload(armotypes.KubescapeNamespace, "ConfigMap", registryScanConfigmap)
+	configMap, err := registryScan.k8sAPI.GetWorkload(registryScan.config.Namespace(), "ConfigMap", registryScanConfigmap)
 	// in case of an error or missing configmap, fallback to the deprecated namespace
 	if err != nil || configMap == nil {
 		configMap, err = registryScan.k8sAPI.GetWorkload(armotypes.ArmoSystemNamespace, "ConfigMap", registryScanConfigmap)
@@ -801,9 +801,9 @@ func (registryScan *registryScan) setRegistryInfoFromConfigMap(registryInfo *arm
 	registryInfo.Exclude = registryConfig.Exclude
 }
 
-func getRegistryScanSecrets(k8sAPI *k8sinterface.KubernetesApi, secretName string) ([]k8sinterface.IWorkload, error) {
+func getRegistryScanSecrets(k8sAPI *k8sinterface.KubernetesApi, namespace, secretName string) ([]k8sinterface.IWorkload, error) {
 	if secretName != "" {
-		secret, err := k8sAPI.GetWorkload(armotypes.KubescapeNamespace, "Secret", secretName)
+		secret, err := k8sAPI.GetWorkload(namespace, "Secret", secretName)
 		if err == nil && secret != nil {
 			return []k8sinterface.IWorkload{secret}, err
 		}
@@ -811,7 +811,7 @@ func getRegistryScanSecrets(k8sAPI *k8sinterface.KubernetesApi, secretName strin
 
 	// when secret name is not provided, we will try to find all secrets starting with kubescape-registry-scan
 	registryScanSecrets := []k8sinterface.IWorkload{}
-	all, err := k8sAPI.ListWorkloads2(armotypes.KubescapeNamespace, "Secret")
+	all, err := k8sAPI.ListWorkloads2(namespace, "Secret")
 	if err == nil {
 		for _, secret := range all {
 			if strings.HasPrefix(secret.GetName(), armotypes.RegistryScanSecretName) {

--- a/mainhandler/imageregistryhandlerhelper.go
+++ b/mainhandler/imageregistryhandlerhelper.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (actionHandler *ActionHandler) updateSecret(sessionObj *utils.SessionObj, secretName string, authConfig *types.AuthConfig) error {
-	secretObj, err := actionHandler.k8sAPI.KubernetesClient.CoreV1().Secrets(armotypes.KubescapeNamespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	secretObj, err := actionHandler.k8sAPI.KubernetesClient.CoreV1().Secrets(actionHandler.config.Namespace()).Get(context.Background(), secretName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (actionHandler *ActionHandler) updateSecret(sessionObj *utils.SessionObj, s
 		return err
 	}
 	secretObj.Data[registriesAuthFieldInSecret] = authMarshal
-	_, err = actionHandler.k8sAPI.KubernetesClient.CoreV1().Secrets(armotypes.KubescapeNamespace).Update(context.Background(), secretObj, metav1.UpdateOptions{})
+	_, err = actionHandler.k8sAPI.KubernetesClient.CoreV1().Secrets(actionHandler.config.Namespace()).Update(context.Background(), secretObj, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (actionHandler *ActionHandler) updateSecret(sessionObj *utils.SessionObj, s
 }
 
 func (actionHandler *ActionHandler) updateConfigMap(sessionObj *utils.SessionObj, configMapName string, registryScan *registryScan) error {
-	configMapObj, err := actionHandler.k8sAPI.KubernetesClient.CoreV1().ConfigMaps(armotypes.KubescapeNamespace).Get(context.Background(), configMapName, metav1.GetOptions{})
+	configMapObj, err := actionHandler.k8sAPI.KubernetesClient.CoreV1().ConfigMaps(actionHandler.config.Namespace()).Get(context.Background(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func (actionHandler *ActionHandler) updateConfigMap(sessionObj *utils.SessionObj
 	}
 	configMapObj.Data[requestBodyFile] = string(command)
 
-	_, err = actionHandler.k8sAPI.KubernetesClient.CoreV1().ConfigMaps(armotypes.KubescapeNamespace).Update(context.Background(), configMapObj, metav1.UpdateOptions{})
+	_, err = actionHandler.k8sAPI.KubernetesClient.CoreV1().ConfigMaps(actionHandler.config.Namespace()).Update(context.Background(), configMapObj, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (actionHandler *ActionHandler) updateConfigMap(sessionObj *utils.SessionObj
 }
 
 func (actionHandler *ActionHandler) updateCronJob(sessionObj *utils.SessionObj, cronJobName string) error {
-	jobTemplateObj, err := actionHandler.k8sAPI.KubernetesClient.BatchV1().CronJobs(armotypes.KubescapeNamespace).Get(context.Background(), cronJobName, metav1.GetOptions{})
+	jobTemplateObj, err := actionHandler.k8sAPI.KubernetesClient.BatchV1().CronJobs(actionHandler.config.Namespace()).Get(context.Background(), cronJobName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -86,7 +86,7 @@ func (actionHandler *ActionHandler) updateCronJob(sessionObj *utils.SessionObj, 
 	jobTemplateObj.Spec.JobTemplate.Spec.Template.Annotations[armotypes.CronJobTemplateAnnotationUpdateJobIDDeprecated] = actionHandler.command.JobTracking.JobID // deprecated
 	jobTemplateObj.Spec.JobTemplate.Spec.Template.Annotations[armotypes.CronJobTemplateAnnotationUpdateJobID] = actionHandler.command.JobTracking.JobID
 
-	_, err = actionHandler.k8sAPI.KubernetesClient.BatchV1().CronJobs(armotypes.KubescapeNamespace).Update(context.Background(), jobTemplateObj, metav1.UpdateOptions{})
+	_, err = actionHandler.k8sAPI.KubernetesClient.BatchV1().CronJobs(actionHandler.config.Namespace()).Update(context.Background(), jobTemplateObj, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}
@@ -223,9 +223,9 @@ func (actionHandler *ActionHandler) deleteRegistryScanCronJob(ctx context.Contex
 	}
 
 	name := jobParams.JobName
-	err := actionHandler.k8sAPI.KubernetesClient.BatchV1().CronJobs(armotypes.KubescapeNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err := actionHandler.k8sAPI.KubernetesClient.BatchV1().CronJobs(actionHandler.config.Namespace()).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil {
-		err = actionHandler.k8sAPI.KubernetesClient.BatchV1beta1().CronJobs(armotypes.KubescapeNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+		err = actionHandler.k8sAPI.KubernetesClient.BatchV1beta1().CronJobs(actionHandler.config.Namespace()).Delete(context.Background(), name, metav1.DeleteOptions{})
 		if err != nil {
 			logger.L().Info("deleteRegistryScanCronJob: deleteCronJob failed", helpers.Error(err))
 			return err
@@ -234,7 +234,7 @@ func (actionHandler *ActionHandler) deleteRegistryScanCronJob(ctx context.Contex
 	logger.L().Info(fmt.Sprintf("deleteRegistryScanCronJob: cronjob: %v deleted successfully", name))
 
 	// delete secret
-	err = actionHandler.k8sAPI.KubernetesClient.CoreV1().Secrets(armotypes.KubescapeNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err = actionHandler.k8sAPI.KubernetesClient.CoreV1().Secrets(actionHandler.config.Namespace()).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil {
 		// if secret not found, it means was configured without credentials
 		if !strings.Contains(err.Error(), "not found") {
@@ -244,7 +244,7 @@ func (actionHandler *ActionHandler) deleteRegistryScanCronJob(ctx context.Contex
 	logger.L().Info(fmt.Sprintf("deleteRegistryScanCronJob: secret: %v deleted successfully", name))
 
 	// delete configmap
-	err = actionHandler.k8sAPI.KubernetesClient.CoreV1().ConfigMaps(armotypes.KubescapeNamespace).Delete(context.Background(), name, metav1.DeleteOptions{})
+	err = actionHandler.k8sAPI.KubernetesClient.CoreV1().ConfigMaps(actionHandler.config.Namespace()).Delete(context.Background(), name, metav1.DeleteOptions{})
 	if err != nil {
 		logger.L().Info("deleteRegistryScanCronJob: deleteConfigMap failed", helpers.Error(err))
 	}

--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -589,7 +589,7 @@ func (actionHandler *ActionHandler) sendCommandForContainers(ctx context.Context
 
 	// we build a list of all registry scan secrets
 	containerRegistryAuths := []registryAuth{}
-	if secrets, err := getRegistryScanSecrets(actionHandler.k8sAPI, ""); err == nil && len(secrets) > 0 {
+	if secrets, err := getRegistryScanSecrets(actionHandler.k8sAPI, actionHandler.config.Namespace(), ""); err == nil && len(secrets) > 0 {
 		for i := range secrets {
 			if auths, err := parseRegistryAuthSecret(secrets[i]); err == nil {
 				containerRegistryAuths = append(containerRegistryAuths, auths...)


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses issue #173 by ensuring that the namespace configured in the application is used for all Kubernetes operations. Previously, the namespace was hardcoded as `armotypes.KubescapeNamespace`, which could lead to issues if the application was configured to use a different namespace. The changes involve replacing the hardcoded namespace with a call to `config.Namespace()`, which retrieves the currently configured namespace.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`mainhandler/imageregistryhandler.go`: Replaced hardcoded namespace with the configured one in various Kubernetes operations such as creating secrets, configmaps, and cronjobs, and getting registry scan secrets and workloads.
`mainhandler/imageregistryhandlerhelper.go`: Updated the namespace used in operations like updating secrets, configmaps, and cronjobs, and deleting registry scan cronjobs.
`mainhandler/vulnscan.go`: Adjusted the namespace used when getting registry scan secrets.
</details>

___
## User Description:
## Overview
This PR fixes #173 

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [ ] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
