### PR TITLE
feat(continuousscan): don't trigger host scanner

### DIFF
--- a/continuousscanning/handlers.go
+++ b/continuousscanning/handlers.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"
+	"k8s.io/utils/ptr"
 
 	armoapi "github.com/armosec/armoapi-go/apis"
 	armowlid "github.com/armosec/utils-k8s-go/wlid"
@@ -41,6 +42,7 @@ func makeScanArgs(so *objectsenvelopes.ScanObject, isDeletedSO bool) map[string]
 	psr := opautilsmetav1.PostScanRequest{
 		ScanObject:          so,
 		IsDeletedScanObject: &isDeletedSO,
+		HostScanner:         ptr.To(false),
 	}
 
 	return map[string]interface{}{

--- a/continuousscanning/service_test.go
+++ b/continuousscanning/service_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 )
 
 type syncSlice[T any] struct {
@@ -210,7 +210,8 @@ func TestContinuousScanningService(t *testing.T) {
 					Args: map[string]interface{}{
 						utils.KubescapeScanV1: opautilsmetav1.PostScanRequest{
 							ScanObject:          makePodScanObject(makePod("default", "first", "")),
-							IsDeletedScanObject: pointer.Bool(false),
+							HostScanner:         ptr.To(false),
+							IsDeletedScanObject: ptr.To(false),
 						},
 					},
 				},
@@ -220,7 +221,8 @@ func TestContinuousScanningService(t *testing.T) {
 					Args: map[string]interface{}{
 						utils.KubescapeScanV1: opautilsmetav1.PostScanRequest{
 							ScanObject:          makePodScanObject(makePod("default", "second", "")),
-							IsDeletedScanObject: pointer.Bool(false),
+							HostScanner:         ptr.To(false),
+							IsDeletedScanObject: ptr.To(false),
 						},
 					},
 				},
@@ -230,7 +232,8 @@ func TestContinuousScanningService(t *testing.T) {
 					Args: map[string]interface{}{
 						utils.KubescapeScanV1: opautilsmetav1.PostScanRequest{
 							ScanObject:          makePodScanObject(makePod("default", "third", "")),
-							IsDeletedScanObject: pointer.Bool(false),
+							HostScanner:         ptr.To(false),
+							IsDeletedScanObject: ptr.To(false),
 						},
 					},
 				},


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This pull request introduces a new parameter to the continuous scanning feature that allows skipping the host scanner. The changes include:
- Addition of a `HostScanner` parameter in the `makeScanArgs` function in `handlers.go`.
- Refactoring of the test cases in `service_test.go` to accommodate the new parameter.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`continuousscanning/handlers.go`: A new parameter `HostScanner` has been added to the `makeScanArgs` function. This parameter is set to false, which means the host scanner will not be triggered for continuous scanning requests.
`continuousscanning/service_test.go`: The test cases have been updated to include the new `HostScanner` parameter. The `IsDeletedScanObject` parameter has also been updated to use the `ptr.To` function for consistency.
</details>

___
## User Description:
## Overview
This commit adds a parameter to skip triggering the host scanner for Continuous Scanning requests.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
