### PR TITLE
disable vulnerability manifests deletes

### DIFF
--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -228,10 +228,11 @@ func (wh *WatchHandler) HandleVulnerabilityManifestEvents(vmEvents <-chan watch.
 		}
 
 		if !hasObject {
-			err := wh.storageClient.SpdxV1beta1().VulnerabilityManifests(obj.ObjectMeta.Namespace).Delete(context.TODO(), manifestName, v1.DeleteOptions{})
-			if err != nil {
-				errorCh <- err
-			}
+			// TODO(vladklokun): deletes are disabled for a quick hack
+			// err := wh.storageClient.SpdxV1beta1().VulnerabilityManifests(obj.ObjectMeta.Namespace).Delete(context.TODO(), manifestName, v1.DeleteOptions{})
+			// if err != nil {
+			// errorCh <- err
+			// }
 		}
 	}
 }


### PR DESCRIPTION
## type:
bug_fix

___
## description:
This PR disables the deletion of Vulnerability Manifests in the WatchHandler. This is a temporary hack and needs to be revisited in the future.

___
## main_files_walkthrough:
<details> <summary>files:</summary>

- `watcher/watcher.go`: The deletion of Vulnerability Manifests in the HandleVulnerabilityManifestEvents function has been commented out. This prevents the deletion of Vulnerability Manifests when the object is not found.
</details>

___
## User Description:
## Overview
This PR fixes #

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [ ] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
