### PR TITLE
bump k8s-interface pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.6
 	github.com/kubescape/backend v0.0.17
 	github.com/kubescape/go-logger v0.0.21
-	github.com/kubescape/k8s-interface v0.0.148
+	github.com/kubescape/k8s-interface v0.0.153
 	github.com/kubescape/opa-utils v0.0.270
 	github.com/kubescape/storage v0.0.29
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ github.com/kubescape/backend v0.0.17 h1:vxUwbvLAvtqcWBpq+8H+PMpT/1zOPPLqL9+sgYan
 github.com/kubescape/backend v0.0.17/go.mod h1:ug9NFmmxT4DcQx3sgdLRzlLPWMKGHE/fpbcYUm5G5Qo=
 github.com/kubescape/go-logger v0.0.21 h1:4ZRIEw3UGUH6BG/cH3yiqFipzQSfGAoCrxlsZuk37ys=
 github.com/kubescape/go-logger v0.0.21/go.mod h1:x3HBpZo3cMT/WIdy18BxvVVd5D0e/PWFVk/HiwBNu3g=
-github.com/kubescape/k8s-interface v0.0.148 h1:vtXDUjvCow5wMdDvb5c/Td9SpafeRqsV/LnOd0NVVsE=
-github.com/kubescape/k8s-interface v0.0.148/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
+github.com/kubescape/k8s-interface v0.0.153 h1:EXYmQuLrCf7nJZnhNFRyeIwGbiSrNLIXy9p2EP9ZiXQ=
+github.com/kubescape/k8s-interface v0.0.153/go.mod h1:5sz+5Cjvo98lTbTVDiDA4MmlXxeHSVMW/wR0V3hV4K8=
 github.com/kubescape/opa-utils v0.0.270 h1:DXTw+p7vJE44s8btYlcxqJdpkFlXuhKeveSJWEFC0jM=
 github.com/kubescape/opa-utils v0.0.270/go.mod h1:VmplJnkhei6mDna+6z183k/HX6GOPgsXiwIlDW8mhKw=
 github.com/kubescape/rbac-utils v0.0.20 h1:1MMxsCsCZ3ntDi8f9ZYYcY+K7bv50bDW5ZvnGnhMhJw=

--- a/watcher/watcher_test.go
+++ b/watcher/watcher_test.go
@@ -362,7 +362,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "default-pod-reverse-proxy-2f07-68bd",
+							Name: "pod-reverse-proxy",
 							Annotations: map[string]string{
 								instanceidv1.InstanceIDMetadataKey: "apiVersion-v1/namespace-default/kind-Pod/name-reverse-proxy/containerName-nginx",
 							},
@@ -376,7 +376,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 		},
 		{
 			name:                 "Adding a new Filtered SBOM with known instance ID slug should produce a matching scan command",
-			knownInstanceIDSlugs: []string{"default-pod-reverse-proxy-2f07-68bd"},
+			knownInstanceIDSlugs: []string{"pod-reverse-proxy"},
 			wlidsToContainersToImageIDsMap: WlidsToContainerToImageIDMap{
 				"wlid://cluster-relevant-clutser/namespace-default/deployment-nginx": {
 					"nginx": "nginx@sha256:1f4e3b6489888647ce1834b601c6c06b9f8c03dee6e097e13ed3e28c01ea3ac8c",
@@ -387,7 +387,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "default-pod-reverse-proxy-2f07-68bd",
+							Name: "pod-reverse-proxy",
 							Annotations: map[string]string{
 								instanceidv1.InstanceIDMetadataKey: "apiVersion-v1/namespace-default/kind-Pod/name-reverse-proxy/containerName-nginx",
 								instanceidv1.WlidMetadataKey:       "wlid://cluster-relevant-clutser/namespace-default/deployment-nginx",
@@ -396,7 +396,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					},
 				},
 			},
-			expectedObjectNames: []string{"default-pod-reverse-proxy-2f07-68bd"},
+			expectedObjectNames: []string{"pod-reverse-proxy"},
 			expectedCommands: []*apis.Command{
 				{
 					CommandName: apis.TypeScanImages,
@@ -412,7 +412,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 		},
 		{
 			name:                 "Adding a new Filtered SBOM with known instance ID slug but missing WLID annotation should produce a matching error",
-			knownInstanceIDSlugs: []string{"default-pod-reverse-proxy-2f07-68bd"},
+			knownInstanceIDSlugs: []string{"pod-reverse-proxy"},
 			wlidsToContainersToImageIDsMap: WlidsToContainerToImageIDMap{
 				"wlid://cluster-relevant-clutser/namespace-default/deployment-nginx": {
 					"nginx": "nginx@sha256:1f4e3b6489888647ce1834b601c6c06b9f8c03dee6e097e13ed3e28c01ea3ac8c",
@@ -423,7 +423,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "default-pod-reverse-proxy-2f07-68bd",
+							Name: "pod-reverse-proxy",
 							Annotations: map[string]string{
 								instanceidv1.InstanceIDMetadataKey: "apiVersion-v1/namespace-default/kind-Pod/name-reverse-proxy/containerName-nginx",
 							},
@@ -431,7 +431,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					},
 				},
 			},
-			expectedObjectNames: []string{"default-pod-reverse-proxy-2f07-68bd"},
+			expectedObjectNames: []string{"pod-reverse-proxy"},
 			expectedCommands:    []*apis.Command{},
 			expectedErrors:      []error{ErrMissingWLIDAnnotation},
 		},
@@ -448,7 +448,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name: "default-pod-reverse-proxy-1ba5-4aaf",
+							Name: "pod-reverse-proxy",
 							Annotations: map[string]string{
 								instanceidv1.WlidMetadataKey: "wlid://cluster-relevant-clutser/namespace-routing/deployment-nginx",
 							},
@@ -456,7 +456,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					},
 				},
 			},
-			expectedObjectNames: []string{"default-pod-reverse-proxy-1ba5-4aaf"},
+			expectedObjectNames: []string{"pod-reverse-proxy"},
 			expectedCommands:    []*apis.Command{},
 			expectedErrors:      []error{ErrMissingInstanceIDAnnotation},
 		},
@@ -468,13 +468,13 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Deleted,
 					Object: &spdxv1beta1.SBOMSPDXv2p3Filtered{
 						ObjectMeta: v1.ObjectMeta{
-							Name:        "default-pod-reverse-proxy-1ba5-4aaf",
+							Name:        "pod-reverse-proxy",
 							Annotations: map[string]string{instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 						},
 					},
 				},
 			},
-			expectedObjectNames: []string{"default-pod-reverse-proxy-1ba5-4aaf"},
+			expectedObjectNames: []string{"pod-reverse-proxy"},
 			expectedCommands:    []*apis.Command{},
 			expectedErrors:      []error{},
 		},
@@ -486,7 +486,7 @@ func TestHandleSBOMFilteredEvents(t *testing.T) {
 					Type: watch.Added,
 					Object: &spdxv1beta1.VulnerabilityManifest{
 						ObjectMeta: v1.ObjectMeta{
-							Name:        "default-pod-reverse-proxy-1ba5-4aaf",
+							Name:        "pod-reverse-proxy",
 							Annotations: map[string]string{instanceidv1.InstanceIDMetadataKey: "60d3737f69e6bd1e1573ecbdb395937219428d00687b4e5f1553f6f192c63e6c"},
 						},
 					},


### PR DESCRIPTION
## Type
Enhancement


___

## Description
- The `k8s-interface` package has been updated from version `v0.0.148` to `v0.0.153`.
- The checksums in `go.sum` have been updated to reflect this change.


___

## PR changes walkthrough
<table><thead><tr><th></th><th>Relevant files&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        go.mod<br><br>

**The version of the `k8s-interface` package has been updated <br>from `v0.0.148` to `v0.0.153`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/operator/pull/197/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6"> +1/-1</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>go.sum&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></summary>
      <ul>
        go.sum<br><br>

**The checksums for the `k8s-interface` package have been <br>updated to reflect the new version `v0.0.153`.**
</ul>
    </details>
  </td>
  <td><a href="https://github.com/kubescape/operator/pull/197/files#diff-3295df7234525439d778f1b282d146a4f1ff6b415248aaac074e8042d9f42d63"> +2/-2</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

## User description
## Overview
This PR fixes #

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [ ] Yes, I signed my commits.

<!-- Please provide a brief overview of the changes made in this pull request. e.g. current behavior/future behavior -->

<!-- 
## Additional Information

> Any additional information that may be useful for reviewers to know 
-->

<!--
## How to Test

> Please provide instructions on how to test the changes made in this pull request
-->

<!--
## Examples/Screenshots

> Here you add related screenshots 
-->

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
