### PR TITLE
send skipTLSVerify and Insecure in image scanning command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/armosec/utils-k8s-go v0.0.24
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/deckarep/golang-set/v2 v2.6.0
+	github.com/distribution/reference v0.5.0
 	github.com/docker/docker v24.0.7+incompatible
 	github.com/go-openapi/runtime v0.26.0
 	github.com/google/go-containerregistry v0.16.1
@@ -98,7 +99,6 @@ require (
 	github.com/containerd/typeurl/v2 v2.1.1 // indirect
 	github.com/coreos/go-oidc v2.2.1+incompatible // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v24.0.0+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/mainhandler/imageregistryhandler.go
+++ b/mainhandler/imageregistryhandler.go
@@ -800,7 +800,13 @@ func (registryScan *registryScan) setRegistryInfoFromConfigMap(registryInfo *arm
 	registryInfo.Exclude = registryConfig.Exclude
 }
 
-func getRegistryScanSecrets(k8sAPI *k8sinterface.KubernetesApi, namespace, secretName string) ([]k8sinterface.IWorkload, error) {
+// KubernetesApiSecrets is an interface for getting workloads from k8s api
+type IWorkloadsGetter interface {
+	GetWorkload(namespace, kind, name string) (k8sinterface.IWorkload, error)
+	ListWorkloads2(namespace, kind string) ([]k8sinterface.IWorkload, error)
+}
+
+func getRegistryScanSecrets(k8sAPI IWorkloadsGetter, namespace, secretName string) ([]k8sinterface.IWorkload, error) {
 	if secretName != "" {
 		secret, err := k8sAPI.GetWorkload(namespace, "Secret", secretName)
 		if err == nil && secret != nil {

--- a/mainhandler/testdata/vulnscan/registry-secret.json
+++ b/mainhandler/testdata/vulnscan/registry-secret.json
@@ -1,0 +1,15 @@
+{
+    "apiVersion": "v1",
+    "kind": "Secret",
+    "type": "Opaque",
+    "data": {
+        "registriesAuth": "WyAgICAgCiAgewogICAgInJlZ2lzdHJ5IjogImRvY2tlci5pbyIsCiAgICAidXNlcm5hbWUiOiAidGVzdC11c2VyIiwKICAgICJwYXNzd29yZCI6ICJ0ZXN0LXBhc3MiLAogICAgImF1dGhfbWV0aG9kIjogImNyZWRlbnRpYWxzIiwKICAgICJodHRwIjogdHJ1ZQogIH0sCiAgewogICAgInJlZ2lzdHJ5IjogInF1YXkuaW8iLAogICAgInVzZXJuYW1lIjogInRlc3QtdXNlci1xdWF5IiwKICAgICJwYXNzd29yZCI6ICJ0ZXN0LXBhc3MtcXVheSIsCiAgICAiYXV0aF9tZXRob2QiOiAiY3JlZGVudGlhbHMiLAogICAgInNraXBUbHNWZXJpZnkiOiB0cnVlCiAgfQpdCg=="
+    },
+    "metadata": {
+        "creationTimestamp": "2024-03-03T13:45:44Z",
+        "name": "kubescape-registry-scan-test-secret",
+        "namespace": "kubescape",
+        "resourceVersion": "80227",
+        "uid": "0617be65-cf6c-4cac-8bcf-d26592b34156"
+    }
+}

--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -427,14 +427,16 @@ func getImageScanConfig(k8sAPI IWorkloadsGetter, namespace string, pod *corev1.P
 		}
 	}
 
-	// TODO: this should not happen every scan
-	// build a list of secrets from the the registry secrets
-	secrets, err := cloudsupport.GetImageRegistryCredentials(imageTag, pod)
-	if err != nil {
-		return nil, err
-	}
-	for i := range secrets {
-		imageScanConfig.authConfigs = append(imageScanConfig.authConfigs, secrets[i])
+	if pod != nil {
+		// TODO: this should not happen every scan
+		// build a list of secrets from the the registry secrets
+		secrets, err := cloudsupport.GetImageRegistryCredentials(imageTag, pod)
+		if err != nil {
+			return nil, err
+		}
+		for i := range secrets {
+			imageScanConfig.authConfigs = append(imageScanConfig.authConfigs, secrets[i])
+		}
 	}
 
 	return &imageScanConfig, nil

--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -365,6 +365,7 @@ func (actionHandler *ActionHandler) getImageScanCommand(containerData *utils.Con
 				JobIDs:      make([]string, 0),
 				Timestamp:   sessionObj.Reporter.GetTimestamp(),
 			},
+			Args:            map[string]interface{}{},
 			ImageTag:        containerData.ImageTag,
 			Credentialslist: imageScanConfig.authConfigs,
 			JobID:           sessionObj.Reporter.GetJobID(),

--- a/mainhandler/vulnscan_test.go
+++ b/mainhandler/vulnscan_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/k8s-interface/workloadinterface"
 	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
 )
 
 //go:embed testdata/vulnscan/registry-secret.json
@@ -45,13 +44,13 @@ func Test_ActionHandler_getImageScanConfig(t *testing.T) {
 
 	k8sApiMock := &WorkloadsGetterMock{}
 
-	res, err := getImageScanConfig(k8sApiMock, "", &v1.Pod{}, "nginx:latest") // no registry treated as docker.io
+	res, err := getImageScanConfig(k8sApiMock, "", nil, "nginx:latest") // no registry treated as docker.io
 	assert.NoError(t, err)
 	assert.Equal(t, expectedAuthConfigs, res.authConfigs)
 	assert.True(t, *res.insecure)
 	assert.Nil(t, res.skipTLSVerify)
 
-	res, err = getImageScanConfig(k8sApiMock, "", &v1.Pod{}, "quay.IO/kubescape/nginx:latest")
+	res, err = getImageScanConfig(k8sApiMock, "", nil, "quay.IO/kubescape/nginx:latest")
 	assert.NoError(t, err)
 	assert.Equal(t, expectedAuthConfigs, res.authConfigs)
 	assert.Nil(t, res.insecure)

--- a/mainhandler/vulnscan_test.go
+++ b/mainhandler/vulnscan_test.go
@@ -1,1 +1,59 @@
 package mainhandler
+
+import (
+	"testing"
+
+	_ "embed"
+
+	dockerregistry "github.com/docker/docker/api/types/registry"
+	"github.com/kubescape/k8s-interface/k8sinterface"
+	"github.com/kubescape/k8s-interface/workloadinterface"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+)
+
+//go:embed testdata/vulnscan/registry-secret.json
+var registrySecret []byte
+
+type WorkloadsGetterMock struct{}
+
+func (mock *WorkloadsGetterMock) GetWorkload(namespace, kind, name string) (k8sinterface.IWorkload, error) {
+	wl, err := workloadinterface.NewWorkload(registrySecret)
+	if err != nil {
+		panic(err)
+	}
+	return wl, nil
+}
+func (mock *WorkloadsGetterMock) ListWorkloads2(namespace, kind string) ([]k8sinterface.IWorkload, error) {
+	wl, _ := mock.GetWorkload(namespace, kind, "")
+	return []k8sinterface.IWorkload{wl}, nil
+}
+
+func Test_ActionHandler_getImageScanConfig(t *testing.T) {
+	expectedAuthConfigs := []dockerregistry.AuthConfig{
+		{
+			Username:      "test-user",
+			Password:      "test-pass",
+			ServerAddress: "docker.io",
+		},
+		{
+			Username:      "test-user-quay",
+			Password:      "test-pass-quay",
+			ServerAddress: "quay.io",
+		},
+	}
+
+	k8sApiMock := &WorkloadsGetterMock{}
+
+	res, err := getImageScanConfig(k8sApiMock, "", &v1.Pod{}, "nginx:latest") // no registry treated as docker.io
+	assert.NoError(t, err)
+	assert.Equal(t, expectedAuthConfigs, res.authConfigs)
+	assert.True(t, *res.insecure)
+	assert.Nil(t, res.skipTLSVerify)
+
+	res, err = getImageScanConfig(k8sApiMock, "", &v1.Pod{}, "quay.IO/kubescape/nginx:latest")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedAuthConfigs, res.authConfigs)
+	assert.Nil(t, res.insecure)
+	assert.True(t, *res.skipTLSVerify)
+}


### PR DESCRIPTION
## Overview
This PR fixes https://github.com/kubescape/kubevuln/issues/209

When scanning individual images the operator did not send the `skipTLSVerify` and `http` attributes (for insecure registries). These attributes are supported in the registry scan secret 
(see  https://kubescape.io/docs/operator/vulnerabilities/#granting-credentials-directly )

As part of the fix, when parsing the secret, we match the registry name of the scanned image with the registry name in the secret. If such match found, we pass the values to the scan command args.

When scanning image registry, the scan command did include these fields so no change is needed.