### PR TITLE
remove deprecated system-tests

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -37,12 +37,6 @@ jobs:
       BUILD_PLATFORM: linux/amd64,linux/arm64
       GO_VERSION: "1.21"
       REQUIRED_TESTS: '[
-                        "vulnerability_scanning", 
-                        "vulnerability_scanning_trigger_scan_on_new_image", 
-                        "vulnerability_scanning_trigger_scan_public_registry", 
-                        "vulnerability_scanning_trigger_scan_public_registry_excluded", 
-                        "vulnerability_scanning_trigger_scan_private_quay_registry", 
-                        "vulnerability_scanning_triggering_with_cron_job", 
                         "registry_scanning_triggering_with_cron_job", 
                         "ks_microservice_ns_creation",
                         "ks_microservice_on_demand", 
@@ -52,8 +46,6 @@ jobs:
                         "ks_microservice_update_cronjob_schedule", 
                         "ks_microservice_delete_cronjob", 
                         "ks_microservice_create_2_cronjob_mitre_and_nsa",
-                        "vulnerability_scanning_test_public_registry_connectivity_by_backend",
-                        "vulnerability_scanning_test_public_registry_connectivity_excluded_by_backend",
                         "relevantCVEs",
                         "relevancy_enabled_stop_sniffing",
                         "relevant_data_is_appended",


### PR DESCRIPTION
## **Type**
tests


___

## **Description**
- This PR removes deprecated vulnerability scanning tests from the CI workflow configuration, specifically targeting tests that are no longer relevant or supported.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-merged.yaml</strong><dd><code>Removal of Deprecated Vulnerability Scanning Tests from CI Workflow</code></dd></summary>
<hr>

.github/workflows/pr-merged.yaml
<li>Removed deprecated vulnerability scanning tests from the required <br>tests list.<br>


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/operator/pull/213/files#diff-d171229d8816dfbc2f3d1a5af7874334d947f2c2e531e575cc84216793d86b49">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

