### PR TITLE
solved locked routine when image has more than 1 tag

### DIFF
--- a/mainhandler/imageregistryhandler.go
+++ b/mainhandler/imageregistryhandler.go
@@ -169,7 +169,7 @@ func (reg *registryAuth) initDefaultValues(ctx context.Context) error {
 	switch reg.AuthMethod {
 	case string(accessTokenAuth), "", "credentials":
 		if reg.Password == "" || reg.Username == "" {
-			return errorWithDocumentationRef("auth_method accesstoken requirers username and password")
+			return errorWithDocumentationRef("auth_method accesstoken requires username and password")
 		}
 	case "public":
 		//do nothing
@@ -209,7 +209,7 @@ func (reg *registryAuth) initDefaultValues(ctx context.Context) error {
 			return err
 		}
 	} else {
-		//try to get the kind from the reg name - if not found it will fallback to default kind
+		//try to get the kind from the reg name - if not found it will fall back to default kind
 		reg.Kind, _ = regCommon.GetRegistryKind(strings.Split(reg.Registry, "/")[0])
 	}
 	return err
@@ -219,7 +219,7 @@ func (rs *registryScan) filterRepositories(ctx context.Context, repos []string) 
 	if len(rs.registryInfo.Include) == 0 && len(rs.registryInfo.Exclude) == 0 {
 		return repos
 	}
-	filteredRepos := []string{}
+	var filteredRepos []string
 	for _, repo := range repos {
 		// if rs.registry.projectID != "" {
 		// 	if !strings.Contains(repo, rs.registry.projectID+"/") {
@@ -279,7 +279,7 @@ func (registryScan *registryScan) createTriggerRequestSecret(k8sAPI *k8sinterfac
 	return nil
 }
 
-func (registryScan *registryScan) createTriggerRequestConfigMap(k8sAPI *k8sinterface.KubernetesApi, name, registryName string, webSocketScanCMD apis.Command) error {
+func (registryScan *registryScan) createTriggerRequestConfigMap(k8sAPI *k8sinterface.KubernetesApi, name string) error {
 	configMap := corev1.ConfigMap{}
 	configMap.Name = name
 	if configMap.Labels == nil {
@@ -298,7 +298,7 @@ func (registryScan *registryScan) createTriggerRequestConfigMap(k8sAPI *k8sinter
 	}
 
 	// command will be mounted into cronjob by using this configmap
-	configMap.Data[requestBodyFile] = string(command)
+	configMap.Data[requestBodyFile] = command
 
 	if _, err := k8sAPI.KubernetesClient.CoreV1().ConfigMaps(registryScan.config.Namespace()).Create(context.Background(), &configMap, metav1.CreateOptions{}); err != nil {
 		return err
@@ -307,7 +307,7 @@ func (registryScan *registryScan) createTriggerRequestConfigMap(k8sAPI *k8sinter
 }
 
 func (registryScan *registryScan) getImagesForScanning(ctx context.Context, reporter beClientV1.IReportSender) error {
-	logger.L().Info("getImagesForScanning: enumerating repoes...")
+	logger.L().Info("getImagesForScanning: enumerating repos...")
 	errChan := make(chan error)
 	repos, err := registryScan.enumerateRepos(ctx)
 	if err != nil {
@@ -348,13 +348,13 @@ func (registryScan *registryScan) setImageToTagsMap(ctx context.Context, repo st
 	firstPage := regCommon.MakePagination(tagsPageSize)
 	latestTagFound := false
 	tagsDepth := registryScan.registryInfo.Depth
-	tags := []string{}
-	options := []remote.Option{}
+	var tags []string
+	var options []remote.Option
 	if registryScan.isPrivate() {
 		options = append(options, remote.WithAuth(registryScan.registryCredentials()))
 	}
 	if latestTags, err := iRegistry.GetLatestTags(repo, *tagsDepth, options...); err == nil {
-		tags := []string{}
+		var tags []string
 		for _, tag := range latestTags {
 			// filter out signature tags
 			if strings.HasSuffix(tag, ".sig") {
@@ -367,15 +367,10 @@ func (registryScan *registryScan) setImageToTagsMap(ctx context.Context, repo st
 			} else {
 				if tagsForDigestLen > *tagsDepth {
 					tags = append(tags, tagsForDigest[:*tagsDepth]...)
-					errMsg := fmt.Sprintf("image %s has %d tags. scanning only first %d tags - %s", repo, tagsForDigestLen, tagsDepth, strings.Join(tagsForDigest[:*tagsDepth], ","))
+					errMsg := fmt.Sprintf("image %s has %d tags. scanning only first %d tags - %s", repo, tagsForDigestLen, *tagsDepth, strings.Join(tagsForDigest[:*tagsDepth], ","))
 					if sender != nil {
-						errChan := make(chan error)
 						err := errorWithDocumentationRef(errMsg)
 						sender.SendWarning(err.Error(), registryScan.sendReport, true)
-						if err := <-errChan; err != nil {
-							logger.L().Ctx(ctx).Error("GetLatestTags failed to send error report",
-								helpers.String("registry", registryScan.registry.hostname), helpers.Error(err))
-						}
 					}
 					logger.L().Ctx(ctx).Warning("GetImagesForScanning: " + errMsg)
 				} else {
@@ -538,7 +533,7 @@ func (registryScan *registryScan) getCommandForConfigMap() (string, error) {
 	return string(scanV1Bytes), nil
 }
 
-func (registryScan *registryScan) setCronJobTemplate(jobTemplateObj *v1.CronJob, name, schedule, jobID, registryName string) error {
+func (registryScan *registryScan) setCronJobTemplate(jobTemplateObj *v1.CronJob, name, schedule, registryName string) error {
 	jobTemplateObj.Name = name
 	if schedule == "" {
 		return fmt.Errorf("schedule cannot be empty")
@@ -646,7 +641,7 @@ func (registryScan *registryScan) createTriggerRequestCronJob(k8sAPI *k8sinterfa
 		return err
 	}
 
-	err = registryScan.setCronJobTemplate(jobTemplateObj, name, getCronTabSchedule(command), command.JobTracking.JobID, registryName)
+	err = registryScan.setCronJobTemplate(jobTemplateObj, name, getCronTabSchedule(command), registryName)
 	if err != nil {
 		return err
 	}
@@ -769,9 +764,9 @@ func (registryScan *registryScan) getRegistryConfig(registryInfo *armotypes.Regi
 	if err != nil {
 		return string(cmDefaultMode), fmt.Errorf("error parsing ConfigMap: %s", err.Error())
 	}
-	for _, config := range registriesConfigs {
-		if config.Registry == registryInfo.RegistryName {
-			registryScan.setRegistryInfoFromConfigMap(registryInfo, config)
+	for _, c := range registriesConfigs {
+		if c.Registry == registryInfo.RegistryName {
+			registryScan.setRegistryInfoFromConfigMap(registryInfo, c)
 			return string(cmLoadedMode), nil
 		}
 	}
@@ -805,7 +800,7 @@ func getRegistryScanSecrets(k8sAPI IWorkloadsGetter, namespace, secretName strin
 	}
 
 	// when secret name is not provided, we will try to find all secrets starting with kubescape-registry-scan
-	registryScanSecrets := []k8sinterface.IWorkload{}
+	var registryScanSecrets []k8sinterface.IWorkload
 	all, err := k8sAPI.ListWorkloads2(namespace, "Secret")
 	if err == nil {
 		for _, secret := range all {

--- a/mainhandler/imageregistryhandlerhelper.go
+++ b/mainhandler/imageregistryhandlerhelper.go
@@ -188,7 +188,7 @@ func (actionHandler *ActionHandler) setRegistryScanCronJob(ctx context.Context, 
 	}
 
 	// create configmap with POST data to trigger websocket
-	err = registryScan.createTriggerRequestConfigMap(actionHandler.k8sAPI, name, registryScan.registryInfo.RegistryName, sessionObj.Command)
+	err = registryScan.createTriggerRequestConfigMap(actionHandler.k8sAPI, name)
 	if err != nil {
 		logger.L().Info("In setRegistryScanCronJob: createTriggerRequestConfigMap failed", helpers.Error(err))
 		sessionObj.Reporter.SetDetails("createTriggerRequestConfigMap")


### PR DESCRIPTION
## **Type**
bug_fix, enhancement


___

## **Description**
- Corrected spelling mistakes in error messages and comments.
- Changed slice initialization for clarity and consistency.
- Updated `createTriggerRequestConfigMap` and `setCronJobTemplate` functions to remove unnecessary parameters.
- Fixed incorrect logging message during image scanning.
- Improved error handling and logging for the process of scanning image tags.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>imageregistryhandler.go</strong><dd><code>Refactoring and Bug Fixes in Image Registry Handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mainhandler/imageregistryhandler.go
<li>Fixed typos in error messages and comments.<br> <li> Simplified slice initialization.<br> <li> Removed unnecessary parameters in <code>createTriggerRequestConfigMap</code> and <br><code>setCronJobTemplate</code> functions.<br> <li> Corrected log message from "repoes" to "repos".<br> <li> Enhanced error handling and logging for image tag scanning.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/operator/pull/218/files#diff-fd2c7d78e0235e59c7ff956ff42dc847977c1532718b7d84b9acec4d948bda2c">+16/-21</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>imageregistryhandlerhelper.go</strong><dd><code>Update ConfigMap Creation Call to Match New Signature</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mainhandler/imageregistryhandlerhelper.go
<li>Updated <code>createTriggerRequestConfigMap</code> call to match its new signature.


</details>
    

  </td>
  <td><a href="https://github.com/kubescape/operator/pull/218/files#diff-f7ea744ca7529b41acd827e9fad5bb51eb8fbc0e1eb833c4888b9bfcaf84df0f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

