### PR TITLE
fix: scan complete application profiles

### DIFF
--- a/mainhandler/vulnscan.go
+++ b/mainhandler/vulnscan.go
@@ -498,6 +498,10 @@ func (actionHandler *ActionHandler) scanApplicationProfile(ctx context.Context, 
 		},
 	}
 
+	if actionHandler.reporter != nil {
+		prepareSessionChain(sessionObj, cmd, actionHandler)
+	}
+
 	if err := sendCommandToScanner(ctx, actionHandler.config, cmd, apis.TypeScanApplicationProfile); err != nil {
 		return fmt.Errorf("failed to send command to scanner with err %v", err)
 	}
@@ -532,9 +536,9 @@ func (actionHandler *ActionHandler) getImageScanCommand(containerData *utils.Con
 		cmd.Args[identifiers.AttributeUseHTTP] = true
 	}
 
-	// Add instanceID only if not empty
-	if containerData.InstanceID != "" {
-		cmd.InstanceID = &containerData.InstanceID
+	// Add instanceID only if container is not empty
+	if containerData.Slug != "" {
+		cmd.InstanceID = &containerData.Slug
 	}
 	if actionHandler.reporter != nil {
 		prepareSessionChain(sessionObj, cmd, actionHandler)

--- a/utils/applicationprofile.go
+++ b/utils/applicationprofile.go
@@ -25,6 +25,10 @@ func SkipApplicationProfile(annotations map[string]string) (bool, error) {
 		return true, fmt.Errorf("no annotations") // skip
 	}
 
+	if completionStatus, ok := annotations[helpersv1.CompletionMetadataKey]; !ok || completionStatus != helpersv1.Complete {
+		return true, fmt.Errorf("partial - workload restart required") // skip
+	}
+
 	if status, ok := annotations[helpersv1.StatusMetadataKey]; ok && !slices.Contains(ann, status) {
 		return true, fmt.Errorf("invalid status")
 	}

--- a/utils/applicationprofile_test.go
+++ b/utils/applicationprofile_test.go
@@ -18,6 +18,7 @@ func TestSkipApplicationProfile(t *testing.T) {
 		{
 			name: "status is empty",
 			annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: "complete",
 				helpersv1.StatusMetadataKey:     "",
 				helpersv1.WlidMetadataKey:       "wlid",
 				helpersv1.InstanceIDMetadataKey: "instanceID",
@@ -27,6 +28,7 @@ func TestSkipApplicationProfile(t *testing.T) {
 		{
 			name: "status is Ready",
 			annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: "complete",
 				helpersv1.StatusMetadataKey:     helpersv1.Ready,
 				helpersv1.WlidMetadataKey:       "wlid",
 				helpersv1.InstanceIDMetadataKey: "instanceID",
@@ -34,8 +36,41 @@ func TestSkipApplicationProfile(t *testing.T) {
 			wantSkip: false,
 		},
 		{
+			name: "partial AP",
+			annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: "partial",
+				helpersv1.StatusMetadataKey:     helpersv1.Ready,
+				helpersv1.WlidMetadataKey:       "wlid",
+				helpersv1.InstanceIDMetadataKey: "instanceID",
+			},
+			wantSkip:    true,
+			expectedErr: fmt.Errorf("partial - workload restart required"),
+		},
+		{
+			name: "invalid completion status",
+			annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: "invalid",
+				helpersv1.StatusMetadataKey:     helpersv1.Ready,
+				helpersv1.WlidMetadataKey:       "wlid",
+				helpersv1.InstanceIDMetadataKey: "instanceID",
+			},
+			wantSkip:    true,
+			expectedErr: fmt.Errorf("partial - workload restart required"),
+		},
+		{
+			name: "missing completion status",
+			annotations: map[string]string{
+				helpersv1.StatusMetadataKey:     helpersv1.Ready,
+				helpersv1.WlidMetadataKey:       "wlid",
+				helpersv1.InstanceIDMetadataKey: "instanceID",
+			},
+			wantSkip:    true,
+			expectedErr: fmt.Errorf("partial - workload restart required"),
+		},
+		{
 			name: "status is Completed",
 			annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: "complete",
 				helpersv1.StatusMetadataKey:     helpersv1.Completed,
 				helpersv1.WlidMetadataKey:       "wlid",
 				helpersv1.InstanceIDMetadataKey: "instanceID",
@@ -45,13 +80,14 @@ func TestSkipApplicationProfile(t *testing.T) {
 		{
 			name: "status is not recognized",
 			annotations: map[string]string{
-				helpersv1.StatusMetadataKey: "NotRecognized",
+				helpersv1.CompletionMetadataKey: "complete",
+				helpersv1.StatusMetadataKey:     "NotRecognized",
 			},
 			wantSkip:    true,
 			expectedErr: fmt.Errorf("invalid status"),
 		},
 		{
-			name:        "no status annotation",
+			name:        "no annotations",
 			annotations: map[string]string{},
 			wantSkip:    true,
 			expectedErr: fmt.Errorf("no annotations"),
@@ -59,18 +95,19 @@ func TestSkipApplicationProfile(t *testing.T) {
 		{
 			name: "missing instance WLID annotation",
 			annotations: map[string]string{
+				helpersv1.CompletionMetadataKey: "complete",
 				helpersv1.StatusMetadataKey:     helpersv1.Ready,
 				helpersv1.InstanceIDMetadataKey: "instanceID",
 			},
 			wantSkip:    true,
 			expectedErr: fmt.Errorf("missing WLID annotation"),
 		},
-
 		{
 			name: "missing instance ID annotation",
 			annotations: map[string]string{
-				helpersv1.StatusMetadataKey: helpersv1.Ready,
-				helpersv1.WlidMetadataKey:   "wlid",
+				helpersv1.CompletionMetadataKey: "complete",
+				helpersv1.StatusMetadataKey:     helpersv1.Ready,
+				helpersv1.WlidMetadataKey:       "wlid",
 			},
 			wantSkip:    true,
 			expectedErr: fmt.Errorf("missing InstanceID annotation"),


### PR DESCRIPTION
## Overview

- Change instance ID field in image scan command to use slug (reverts changes in bf8a747)
- Scan application profiles only for complete ones (not partial)