### PR TITLE
Update k8s-interface to v0.0.187 to support google artifact registry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/gorilla/mux v1.8.1
 	github.com/kubescape/backend v0.0.26
 	github.com/kubescape/go-logger v0.0.23
-	github.com/kubescape/k8s-interface v0.0.184
+	github.com/kubescape/k8s-interface v0.0.187
 	github.com/kubescape/kubescape-network-scanner v0.0.15
 	github.com/kubescape/node-agent v0.2.152
 	github.com/kubescape/opa-utils v0.0.278

--- a/go.sum
+++ b/go.sum
@@ -670,6 +670,8 @@ github.com/kubescape/go-logger v0.0.23 h1:5xh+Nm8eGImhFbtippRKLaFgsvlKE1ufvQhNM2
 github.com/kubescape/go-logger v0.0.23/go.mod h1:Ayg7g769c7sXVB+P3fkJmbsJpoEmMmaUf9jeo+XuC3U=
 github.com/kubescape/k8s-interface v0.0.184 h1:GzqfD9ynIWYEFRuJWgeNSBCfWDHfurKU9eZBiTLHuN4=
 github.com/kubescape/k8s-interface v0.0.184/go.mod h1:YjIAQtrK4nCy+XQ/6jwo+BqlLyJk7DN2Mx4pUcbzq10=
+github.com/kubescape/k8s-interface v0.0.187 h1:nGX8GWBVoek9v4A1RSLAEGjEwiZfSUVx3EouGQBBPL8=
+github.com/kubescape/k8s-interface v0.0.187/go.mod h1:j9snZbH+RxOaa1yG/bWgTClj90q7To0rGgQepxy4b+k=
 github.com/kubescape/kubescape-network-scanner v0.0.15 h1:LsaVCQzj0PbA30BeFdzxchW2bkg6nn5quwllWmm/2/s=
 github.com/kubescape/kubescape-network-scanner v0.0.15/go.mod h1:fqTzRCWsuniGEEZHtOEdITxnqx+i5ICdOVuenSQJd3U=
 github.com/kubescape/kubescape/v3 v3.0.4 h1:gZ5d8QMxLYZQ6Yz9wRvGcDQlBUIV+v/Y/41g56/YDy8=


### PR DESCRIPTION
## Overview
This PR fixes #

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x ] Yes, I signed my commits.

This PR updates  k8s-interface to v0.0.187 which contains changes to support google artifact registry.
 