### PR TITLE
fix: private container registry credentials are not used when scanning an application profile

### DIFF
--- a/watcher/applicationprofilewatcher.go
+++ b/watcher/applicationprofilewatcher.go
@@ -2,6 +2,7 @@ package watcher
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -11,8 +12,10 @@ import (
 	"github.com/kubescape/operator/utils"
 	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/panjf2000/ants/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 )
 
 // ApplicationProfileWatch watches and processes changes on ApplicationProfile resources
@@ -103,14 +106,25 @@ func (wh *WatchHandler) HandleApplicationProfileEvents(eventQueue *CooldownQueue
 
 		// TODO check if we can skip processing (based on size?)
 
+		// assemble command arguments
+		args := map[string]interface{}{
+			utils.ArgsName:      obj.Name,
+			utils.ArgsNamespace: obj.Namespace,
+		}
+
+		// load pod spec
+		pod, err := getPod(wh.k8sAPI.KubernetesClient, obj)
+		if err != nil {
+			logger.L().Error("failed loading pod spec", helpers.String("wlid", obj.Annotations[helpersv1.WlidMetadataKey]), helpers.String("name", obj.Name), helpers.String("namespace", obj.Namespace), helpers.Error(err))
+		} else if pod != nil {
+			args[utils.ArgsPod] = pod
+		}
+
 		// create command
 		cmd := &apis.Command{
 			Wlid:        obj.Annotations[helpersv1.WlidMetadataKey],
 			CommandName: utils.CommandScanApplicationProfile,
-			Args: map[string]interface{}{
-				utils.ArgsName:      obj.Name,
-				utils.ArgsNamespace: obj.Namespace,
-			},
+			Args:        args,
 		}
 		// send command
 		logger.L().Info("scanning application profile", helpers.String("wlid", cmd.Wlid), helpers.String("name", obj.Name), helpers.String("namespace", obj.Namespace))
@@ -121,4 +135,18 @@ func (wh *WatchHandler) HandleApplicationProfileEvents(eventQueue *CooldownQueue
 func (wh *WatchHandler) getApplicationProfileWatcher() (watch.Interface, error) {
 	// no need to support ExcludeNamespaces and IncludeNamespaces since node-agent will respect them as well
 	return wh.storageClient.SpdxV1beta1().ApplicationProfiles("").Watch(context.Background(), metav1.ListOptions{})
+}
+
+func getPod(client kubernetes.Interface, obj *spdxv1beta1.ApplicationProfile) (*corev1.Pod, error) {
+	if kind, ok := obj.Labels[helpersv1.KindMetadataKey]; !ok || kind != "Pod" {
+		return nil, nil
+	}
+
+	podName, ok := obj.Labels[helpersv1.NameMetadataKey]
+	if !ok || podName == "" {
+		return nil, fmt.Errorf("label %s is missing", helpersv1.NameMetadataKey)
+	}
+
+	pod, err := client.CoreV1().Pods(obj.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+	return pod, err
 }


### PR DESCRIPTION
## Overview

When the operator processes an `ApplicationProfile` event and sends a `scanApplicationProfile` command the following arguments are supplied:
[arguments](https://github.com/kubescape/operator/blob/d69efef8bd4a384dfafadf82ee21ca1d0a72e1f6/watcher/applicationprofilewatcher.go#L110-L113)

When that command is then executed, credentials are not passed on because the `pod` argument is missing:
[obtaining credentials](https://github.com/kubescape/operator/blob/d69efef8bd4a384dfafadf82ee21ca1d0a72e1f6/mainhandler/vulnscan.go#L257-L262)

## Solution

The pod is loaded and passed so that the credentials are loaded.

## Additional Information

We observed this issue with pods that are started by Argo Workflows. They only run for a very limited time and thus were not scanned by other means.

I also considered simply passing the imageID as a new argument (because then we wouldn't need to load the whole Pod which may not even exist anymore). This would have been sufficient for my use-case (Azure CR) but then I saw that this wouldn't work for other credential extraction methods like imagePullSecrets - so it's probably not worth it.

## Checklist before requesting a review

put an [x] in the box to get it checked 

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes