### PR TITLE
chore: bump registryx to v0.0.35 (GitLab registry host discovery)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/armosec/armoapi-go v0.0.673
-	github.com/armosec/registryx v0.0.34
+	github.com/armosec/registryx v0.0.35
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35
 	github.com/aws/aws-sdk-go-v2 v1.41.1

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/armosec/armoapi-go v0.0.673 h1:Pwsf/K2Y1U8IExntU0iD+F0iAz1ys6BhiPyqEu
 github.com/armosec/armoapi-go v0.0.673/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
-github.com/armosec/registryx v0.0.34 h1:52EZVjKypW38WwoJLmkTH53ODZhsyYxwdHn2reZatZ8=
-github.com/armosec/registryx v0.0.34/go.mod h1:dm7/1yJllY2MDS8oxGyR+64NAepwDXV4/2Q5mnD8yHs=
+github.com/armosec/registryx v0.0.35 h1:fvP5/IZL0+jJUnNXvAj6ohJ6UVHaASVpR/cPLX0I4f0=
+github.com/armosec/registryx v0.0.35/go.mod h1:dm7/1yJllY2MDS8oxGyR+64NAepwDXV4/2Q5mnD8yHs=
 github.com/armosec/utils-go v0.0.58 h1:g9RnRkxZAmzTfPe2ruMo2OXSYLwVSegQSkSavOfmaIE=
 github.com/armosec/utils-go v0.0.58/go.mod h1:CdqKHKruVJMCxGcZXYW9J+5P9FZou8dMzVpcB0Xt8pk=
 github.com/armosec/utils-k8s-go v0.0.35 h1:CliNObhAca5UYl84m5OQecOTm9ZfMFI8648pYhQJiu4=


### PR DESCRIPTION
## Summary
- Bumps `github.com/armosec/registryx` from v0.0.34 to v0.0.35
- Picks up the GitLab registry host auto-discovery fix : self-hosted GitLab instances where the container registry hostname differs from the web URL now work correctly
- The fix uses the GitLab API `location` field to discover the actual registry hostname, avoiding the `service=dependency_proxy` 403 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->