### PR TITLE
feat(autoscaler): compute GOMEMLIMIT per node group

### DIFF
--- a/.github/workflows/pr-created.yaml
+++ b/.github/workflows/pr-created.yaml
@@ -5,7 +5,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:
       - '*.md'
-      - '*.yaml'
       - '.github/workflows/*'
 
 concurrency:
@@ -22,3 +21,13 @@ jobs:
       CGO_ENABLED: 0
       GO_VERSION: "1.25"
     secrets: inherit
+
+  integration-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+      - name: Build with integration tag
+        run: go test -tags=integration -run=^$ ./...

--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ type NodeAgentAutoscalerConfig struct {
 	ReconcileInterval      time.Duration                          `json:"reconcileInterval" mapstructure:"reconcileInterval"`
 	TemplatePath           string                                 `json:"templatePath" mapstructure:"templatePath"`
 	OperatorDeploymentName string                                 `json:"operatorDeploymentName" mapstructure:"operatorDeploymentName"`
+	GoMemLimitPercentage   float64                                `json:"goMemLimitPercentage" mapstructure:"goMemLimitPercentage"`
 }
 
 type Server struct {
@@ -316,6 +317,7 @@ func LoadConfig(path string) (Config, error) {
 	viper.SetDefault("nodeAgentAutoscaler.reconcileInterval", 5*time.Minute)
 	viper.SetDefault("nodeAgentAutoscaler.templatePath", "/etc/templates/daemonset-template.yaml")
 	viper.SetDefault("nodeAgentAutoscaler.operatorDeploymentName", "operator")
+	viper.SetDefault("nodeAgentAutoscaler.goMemLimitPercentage", 0.8)
 
 	viper.AutomaticEnv()
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,6 +122,7 @@ func TestLoadConfig(t *testing.T) {
 					ReconcileInterval:      5 * time.Minute,
 					TemplatePath:           "/etc/templates/daemonset-template.yaml",
 					OperatorDeploymentName: "operator",
+					GoMemLimitPercentage:   0.8,
 				},
 			},
 		},

--- a/nodeagentautoscaler/autoscaler.go
+++ b/nodeagentautoscaler/autoscaler.go
@@ -54,7 +54,7 @@ type Autoscaler struct {
 
 // NewAutoscaler creates a new Autoscaler instance
 func NewAutoscaler(client kubernetes.Interface, cfg config.NodeAgentAutoscalerConfig, namespace string, operatorDeploymentName string) (*Autoscaler, error) {
-	templateRenderer, err := NewTemplateRenderer(cfg.TemplatePath)
+	templateRenderer, err := NewTemplateRenderer(cfg.TemplatePath, cfg.GoMemLimitPercentage)
 	if err != nil {
 		return nil, err
 	}

--- a/nodeagentautoscaler/autoscaler_test.go
+++ b/nodeagentautoscaler/autoscaler_test.go
@@ -423,14 +423,14 @@ func TestGenerateDaemonSetName(t *testing.T) {
 func TestNewAutoscaler(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	cfg := config.NodeAgentAutoscalerConfig{
-		Enabled:           true,
-		NodeGroupLabel:    "node.kubernetes.io/instance-type",
-		ReconcileInterval: 5 * time.Minute,
-		TemplatePath:      "/tmp/nonexistent-template.yaml", // Will fail
+		Enabled:              true,
+		GoMemLimitPercentage: 0.8,
+		NodeGroupLabel:       "node.kubernetes.io/instance-type",
+		ReconcileInterval:    5 * time.Minute,
+		TemplatePath:         "/tmp/nonexistent-template.yaml", // Will fail
 	}
 
 	// Should fail because template doesn't exist
 	_, err := NewAutoscaler(client, cfg, "kubescape", "operator")
 	assert.Error(t, err)
 }
-

--- a/nodeagentautoscaler/integration_test.go
+++ b/nodeagentautoscaler/integration_test.go
@@ -14,10 +14,11 @@ import (
 // TestIntegration_HelmGeneratedTemplate tests rendering with the actual Helm-generated template
 // Run with: go test -tags=integration -v -run TestIntegration_HelmGeneratedTemplate
 // Requires the template file to be extracted first from Helm:
-//   helm template test ../../helm-charts/charts/kubescape-operator \
-//     --set nodeAgent.autoscaler.enabled=true --set clusterName=test \
-//     | grep -A 300 "daemonset-template.yaml:" | tail -n +2 | sed 's/^    //' \
-//     | awk '/^---/{exit} {print}' > /tmp/test-daemonset-template.yaml
+//
+//	helm template test ../../helm-charts/charts/kubescape-operator \
+//	  --set nodeAgent.autoscaler.enabled=true --set clusterName=test \
+//	  | grep -A 300 "daemonset-template.yaml:" | tail -n +2 | sed 's/^    //' \
+//	  | awk '/^---/{exit} {print}' > /tmp/test-daemonset-template.yaml
 func TestIntegration_HelmGeneratedTemplate(t *testing.T) {
 	templatePath := "/tmp/test-daemonset-template.yaml"
 
@@ -27,7 +28,7 @@ func TestIntegration_HelmGeneratedTemplate(t *testing.T) {
 	}
 
 	// Create renderer
-	renderer, err := NewTemplateRenderer(templatePath)
+	renderer, err := NewTemplateRenderer(templatePath, 0.8)
 	require.NoError(t, err)
 
 	// Test data simulating a node group
@@ -76,4 +77,3 @@ func TestIntegration_HelmGeneratedTemplate(t *testing.T) {
 		container.Resources.Limits.Cpu().String(),
 		container.Resources.Limits.Memory().String())
 }
-

--- a/nodeagentautoscaler/templaterenderer.go
+++ b/nodeagentautoscaler/templaterenderer.go
@@ -25,6 +25,8 @@ type TemplateData struct {
 	NodeGroupLabel string
 	// Resources contains the calculated resource requests and limits
 	Resources TemplateResources
+	// GoMemLimit is the GOMEMLIMIT value derived from the memory limit and percentage (e.g., "360MiB")
+	GoMemLimit string
 }
 
 // TemplateResources holds the resource values for template rendering
@@ -41,17 +43,23 @@ type TemplateResourcePair struct {
 
 // TemplateRenderer loads and renders DaemonSet templates
 type TemplateRenderer struct {
-	templatePath string
-	template     *template.Template
-	mu           sync.RWMutex // Protects template during reload
-	watcher      *fsnotify.Watcher
-	stopCh       chan struct{}
+	templatePath         string
+	template             *template.Template
+	mu                   sync.RWMutex // Protects template during reload
+	watcher              *fsnotify.Watcher
+	stopCh               chan struct{}
+	goMemLimitPercentage float64
 }
 
 // NewTemplateRenderer creates a new TemplateRenderer
-func NewTemplateRenderer(templatePath string) (*TemplateRenderer, error) {
+func NewTemplateRenderer(templatePath string, goMemLimitPercentage float64) (*TemplateRenderer, error) {
+	if goMemLimitPercentage <= 0 || goMemLimitPercentage > 1.0 {
+		return nil, fmt.Errorf("goMemLimitPercentage %v is out of valid range (0, 1.0]", goMemLimitPercentage)
+	}
+
 	tr := &TemplateRenderer{
-		templatePath: templatePath,
+		templatePath:         templatePath,
+		goMemLimitPercentage: goMemLimitPercentage,
 	}
 
 	if err := tr.loadTemplate(); err != nil {
@@ -200,6 +208,9 @@ func formatMemory(q resource.Quantity) string {
 
 // RenderDaemonSet renders a DaemonSet for the given node group and resources
 func (tr *TemplateRenderer) RenderDaemonSet(group NodeGroup, resources CalculatedResources) (*appsv1.DaemonSet, error) {
+	limitBytes := resources.Limits.Memory.Value()
+	goMemLimitMiB := int64(float64(limitBytes) * tr.goMemLimitPercentage / (1024 * 1024))
+
 	data := TemplateData{
 		Name:           fmt.Sprintf("node-agent-%s", group.SanitizedName),
 		NodeGroupLabel: group.LabelValue,
@@ -213,6 +224,7 @@ func (tr *TemplateRenderer) RenderDaemonSet(group NodeGroup, resources Calculate
 				Memory: formatMemory(resources.Limits.Memory),
 			},
 		},
+		GoMemLimit: fmt.Sprintf("%dMiB", goMemLimitMiB),
 	}
 
 	tr.mu.RLock()
@@ -236,7 +248,8 @@ func (tr *TemplateRenderer) RenderDaemonSet(group NodeGroup, resources Calculate
 		helpers.String("requestCPU", data.Resources.Requests.CPU),
 		helpers.String("requestMemory", data.Resources.Requests.Memory),
 		helpers.String("limitCPU", data.Resources.Limits.CPU),
-		helpers.String("limitMemory", data.Resources.Limits.Memory))
+		helpers.String("limitMemory", data.Resources.Limits.Memory),
+		helpers.String("goMemLimit", data.GoMemLimit))
 
 	return ds, nil
 }

--- a/nodeagentautoscaler/templaterenderer_test.go
+++ b/nodeagentautoscaler/templaterenderer_test.go
@@ -110,7 +110,7 @@ spec:
 	require.NoError(t, err)
 
 	// Create renderer
-	renderer, err := NewTemplateRenderer(templatePath)
+	renderer, err := NewTemplateRenderer(templatePath, 0.8)
 	require.NoError(t, err)
 
 	// Test data
@@ -160,9 +160,37 @@ func TestTemplateRenderer_RenderDaemonSet_InvalidTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should fail to create renderer
-	_, err = NewTemplateRenderer(templatePath)
+	_, err = NewTemplateRenderer(templatePath, 0.8)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse template")
+}
+
+func TestTemplateRenderer_NewTemplateRenderer_InvalidPercentage(t *testing.T) {
+	tmpDir := t.TempDir()
+	templatePath := filepath.Join(tmpDir, "daemonset-template.yaml")
+	err := os.WriteFile(templatePath, []byte("apiVersion: apps/v1\nkind: DaemonSet\nmetadata:\n  name: test\nspec:\n  selector:\n    matchLabels:\n      app: test\n  template:\n    metadata:\n      labels:\n        app: test\n    spec:\n      containers:\n      - name: test\n        image: test\n"), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		percentage float64
+	}{
+		{name: "zero", percentage: 0},
+		{name: "negative", percentage: -0.5},
+		{name: "greater than 1.0", percentage: 1.5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewTemplateRenderer(templatePath, tt.percentage)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "out of valid range")
+		})
+	}
+
+	// Boundary: exactly 1.0 should be valid
+	_, err = NewTemplateRenderer(templatePath, 1.0)
+	assert.NoError(t, err)
 }
 
 func TestTemplateRenderer_ReloadTemplate(t *testing.T) {
@@ -225,7 +253,7 @@ spec:
 	require.NoError(t, err)
 
 	// Create renderer
-	renderer, err := NewTemplateRenderer(templatePath)
+	renderer, err := NewTemplateRenderer(templatePath, 0.8)
 	require.NoError(t, err)
 
 	group := NodeGroup{
@@ -262,4 +290,101 @@ spec:
 	assert.Equal(t, "node-agent-test-v2", ds2.Name)
 }
 
+func TestTemplateRenderer_RenderDaemonSet_GoMemLimit(t *testing.T) {
+	templateContent := `apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "{{ .Name }}"
+  namespace: kubescape
+spec:
+  selector:
+    matchLabels:
+      app: node-agent
+  template:
+    metadata:
+      labels:
+        app: node-agent
+    spec:
+      containers:
+      - name: node-agent
+        image: "quay.io/kubescape/node-agent:v0.3.3"
+        resources:
+          requests:
+            cpu: "{{ .Resources.Requests.CPU }}"
+            memory: "{{ .Resources.Requests.Memory }}"
+          limits:
+            cpu: "{{ .Resources.Limits.CPU }}"
+            memory: "{{ .Resources.Limits.Memory }}"
+        env:
+        - name: GOMEMLIMIT
+          value: "{{ .GoMemLimit }}"
+`
 
+	tmpDir := t.TempDir()
+	templatePath := filepath.Join(tmpDir, "daemonset-template.yaml")
+	err := os.WriteFile(templatePath, []byte(templateContent), 0644)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name               string
+		limitMemory        string
+		percentage         float64
+		expectedGoMemLimit string
+	}{
+		{
+			name:               "450Mi at 80% = 360MiB",
+			limitMemory:        "450Mi",
+			percentage:         0.8,
+			expectedGoMemLimit: "360MiB",
+		},
+		{
+			name:               "1Gi at 80% = 819MiB",
+			limitMemory:        "1Gi",
+			percentage:         0.8,
+			expectedGoMemLimit: "819MiB",
+		},
+		{
+			name:               "1800Mi at 80% = 1440MiB",
+			limitMemory:        "1800Mi",
+			percentage:         0.8,
+			expectedGoMemLimit: "1440MiB",
+		},
+		{
+			name:               "900Mi at 80% = 720MiB",
+			limitMemory:        "900Mi",
+			percentage:         0.8,
+			expectedGoMemLimit: "720MiB",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			renderer, err := NewTemplateRenderer(templatePath, tt.percentage)
+			require.NoError(t, err)
+
+			group := NodeGroup{LabelValue: "m5.large", SanitizedName: "m5-large"}
+			resources := CalculatedResources{
+				Requests: ResourcePair{
+					CPU:    resource.MustParse("100m"),
+					Memory: resource.MustParse("200Mi"),
+				},
+				Limits: ResourcePair{
+					CPU:    resource.MustParse("500m"),
+					Memory: resource.MustParse(tt.limitMemory),
+				},
+			}
+
+			ds, err := renderer.RenderDaemonSet(group, resources)
+			require.NoError(t, err)
+
+			var goMemLimitValue string
+			for _, env := range ds.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "GOMEMLIMIT" {
+					goMemLimitValue = env.Value
+					break
+				}
+			}
+			assert.Equal(t, tt.expectedGoMemLimit, goMemLimitValue)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GoMemLimitPercentage` field to `NodeAgentAutoscalerConfig` (default 0.8 = 80%)
- Compute `GOMEMLIMIT` per node group in `TemplateRenderer` as a percentage of the memory limit, and inject it as `GoMemLimit` into the DaemonSet template
- Validate that `goMemLimitPercentage` is in the valid range `(0, 1.0]` at construction time

## Motivation

In autoscaler mode the operator creates per-node-group DaemonSets with dynamically sized resource requests/limits. Previously the DaemonSet template had a static `GOMEMLIMIT` set at Helm install time. This PR makes the operator compute `GOMEMLIMIT` at reconcile time from the actual computed memory limit, so it always stays at the configured percentage (default 80%) of whatever the operator decided the limit should be for that node group.

## Design note: main container vs. sidecar

The operator computes `GOMEMLIMIT` only for the **main node-agent container**, whose resources scale per node group. When the SBOM scanner sidecar is enabled, its resources are **static** (configured via Helm values, uniform across node groups) and its `GOMEMLIMIT` is computed once by Helm at install time — the operator passes the sidecar definition through unchanged. Sidecar resource limits can still be adjusted via `helm upgrade --set nodeAgent.sbomScanner.resources.limits.memory=...`.

## Changes

| File | Change |
|------|--------|
| `config/config.go` | Add `GoMemLimitPercentage float64` to `NodeAgentAutoscalerConfig`; set viper default to 0.8 |
| `nodeagentautoscaler/templaterenderer.go` | Add `goMemLimitPercentage` field; compute `GoMemLimit` in `RenderDaemonSet`; validate percentage in constructor |
| `nodeagentautoscaler/autoscaler.go` | Pass `cfg.GoMemLimitPercentage` to `NewTemplateRenderer` |
| `nodeagentautoscaler/templaterenderer_test.go` | Test GOMEMLIMIT computation for multiple memory/percentage combos; test invalid percentage rejection |

## Test plan

- [x] Unit tests: `TestTemplateRenderer_RenderDaemonSet_GoMemLimit` covers 450Mi→360MiB, 1Gi→819MiB, 1800Mi→1440MiB, 900Mi→720MiB at 80%
- [x] Unit tests: `TestTemplateRenderer_NewTemplateRenderer_InvalidPercentage` verifies rejection of 0, negative, >1.0 and acceptance of 1.0
- [x] All existing tests pass (`go test ./...`)
- [x] Local kind cluster verification: computed GOMEMLIMIT matched expected 80% of memory limit in both with-sidecar and without-sidecar scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `nodeAgentAutoscaler.goMemLimitPercentage` configuration option (defaults to 0.8) with validation for values between 0 and 1.0
  * Autoscaler now populates Go memory limit environment variables on DaemonSets based on memory limits and the configured percentage

* **Tests**
  * Added integration test job to CI/CD pipeline for build verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->