### PR TITLE
kube-init-certgen

### DIFF
--- a/kube-init-certgen/Dockerfile
+++ b/kube-init-certgen/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine/k8s:1.36.1@sha256:692239d739589247c4a791205ed9619c28ae85a21286e19a6211c04a62c56668
+
+RUN apk add --no-cache openssl
+
+COPY scripts/ /scripts/
+RUN chmod +x /scripts/*.sh
+
+WORKDIR /scripts

--- a/kube-init-certgen/Dockerfile
+++ b/kube-init-certgen/Dockerfile
@@ -1,8 +1,12 @@
 FROM alpine/k8s:1.36.1@sha256:692239d739589247c4a791205ed9619c28ae85a21286e19a6211c04a62c56668
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl && \
+    addgroup -S certgen && \
+    adduser -S -G certgen certgen
 
 COPY scripts/ /scripts/
-RUN chmod +x /scripts/*.sh
+RUN chmod +x /scripts/*.sh && \
+    chown -R certgen:certgen /scripts
 
+USER certgen
 WORKDIR /scripts

--- a/kube-init-certgen/README.md
+++ b/kube-init-certgen/README.md
@@ -1,0 +1,57 @@
+# kube-init-certgen
+
+Minimal init-container image for generating TLS certificates and patching Kubernetes resources with the resulting CA bundle. Designed as a replacement for hook-based cert generators (e.g. `kube-webhook-certgen`).
+
+Image: `quay.io/kubescape/kube-init-certgen`
+
+## Used by
+
+- [kubescape/operator](https://github.com/kubescape/operator) — admission webhook (`ValidatingWebhookConfiguration`) cert lifecycle
+- [kubescape/storage](https://github.com/kubescape/storage) — aggregated API (`APIService`) cert lifecycle
+
+## How it works
+
+Two scripts run as sequential init containers on the target workload:
+
+1. **`certgen-create.sh`** — generates a CA + leaf certificate (ECDSA P-256) and stores them in a Kubernetes Secret. Idempotent: if the Secret already exists, it reuses the existing cert without regenerating.
+2. **`certgen-patch.sh`** — reads the CA from the Secret and patches its `caBundle` field into either a `ValidatingWebhookConfiguration` or an `APIService`. Retries until the resource is available.
+
+Because both scripts run as init containers, the main container only starts after certs are ready and the caBundle is patched — ArgoCD's health check naturally waits on this.
+
+## Image contents
+
+Base: `alpine/k8s:1.36.1` (includes `kubectl`, `jq`, `bash`)
+Added: `openssl` (via `apk`)
+
+## Scripts
+
+### certgen-create.sh
+
+```
+--namespace      <ns>        Namespace for the secret (required)
+--secret-name    <name>      Name of the secret to read/create (required)
+--host           <hosts>     Comma-separated DNS SANs for the leaf cert (required)
+--out-dir        <path>      Directory to write cert/key into (required)
+--ca-name        <key>       Secret key for the CA cert (default: ca)
+--cert-name      <key>       Secret key for the leaf cert (default: cert)
+--key-name       <key>       Secret key for the leaf key (default: key)
+--days           <n>         Certificate validity in days (default: 36500)
+```
+
+### certgen-patch.sh
+
+```
+--namespace      <ns>        Namespace of the secret (required)
+--secret-name    <name>      Name of the secret holding the CA (required)
+--resource-type  vwc|apiservice  Resource type to patch (required)
+--resource-name  <name>      Name of the resource to patch (required)
+--ca-name        <key>       Secret key for the CA cert (default: ca)
+--retries        <n>         Max patch attempts (default: 60)
+--retry-interval <s>         Seconds between attempts (default: 5)
+```
+
+## Building
+
+```sh
+docker buildx build --platform linux/amd64,linux/arm64 -t quay.io/kubescape/kube-init-certgen:latest --push .
+```

--- a/kube-init-certgen/scripts/certgen-create.sh
+++ b/kube-init-certgen/scripts/certgen-create.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE=""
+SECRET_NAME=""
+HOSTS=""
+OUT_DIR=""
+CA_NAME="ca"
+CERT_NAME="cert"
+KEY_NAME="key"
+SECRET_TYPE="Opaque"
+DAYS="36500"
+
+usage() {
+  cat >&2 <<EOF
+Usage: certgen-create.sh [flags]
+  -n, --namespace      Namespace for the secret (required)
+  -s, --secret-name    Name of the secret to read/create (required)
+  -H, --host           Comma-separated DNS SANs for the leaf cert (required)
+  -o, --out-dir        Directory to write the leaf cert/key into (required)
+      --ca-name        Key in the secret for the CA cert (default: ca)
+      --cert-name      Key in the secret for the leaf cert (default: cert)
+      --key-name       Key in the secret for the leaf key (default: key)
+      --secret-type    Type of the secret (default: Opaque)
+      --days           Validity in days (default: 36500 ~= 100y)
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace)   NAMESPACE="$2";   shift 2;;
+    -s|--secret-name) SECRET_NAME="$2"; shift 2;;
+    -H|--host)        HOSTS="$2";       shift 2;;
+    -o|--out-dir)     OUT_DIR="$2";     shift 2;;
+    --ca-name)        CA_NAME="$2";     shift 2;;
+    --cert-name)      CERT_NAME="$2";   shift 2;;
+    --key-name)       KEY_NAME="$2";    shift 2;;
+    --secret-type)    SECRET_TYPE="$2"; shift 2;;
+    --days)           DAYS="$2";        shift 2;;
+    -h|--help)        usage;;
+    *) echo "unknown flag: $1" >&2; usage;;
+  esac
+done
+
+[[ -n "$NAMESPACE"   ]] || { echo "--namespace required"   >&2; usage; }
+[[ -n "$SECRET_NAME" ]] || { echo "--secret-name required" >&2; usage; }
+[[ -n "$HOSTS"       ]] || { echo "--host required"        >&2; usage; }
+[[ -n "$OUT_DIR"     ]] || { echo "--out-dir required"     >&2; usage; }
+
+mkdir -p "$OUT_DIR"
+
+# --- path 1: secret already exists -> just materialize cert / key ---
+if SECRET_JSON="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o json 2>/dev/null)"; then
+  echo "secret $NAMESPACE/$SECRET_NAME exists, reusing"
+  echo "$SECRET_JSON" | jq -er --arg k "$CERT_NAME" '.data[$k] // empty' | base64 -d > "$OUT_DIR/$CERT_NAME"
+  echo "$SECRET_JSON" | jq -er --arg k "$KEY_NAME"  '.data[$k] // empty' | base64 -d > "$OUT_DIR/$KEY_NAME"
+  [[ -s "$OUT_DIR/$CERT_NAME" && -s "$OUT_DIR/$KEY_NAME" ]] || { echo "secret missing $CERT_NAME/$KEY_NAME" >&2; exit 1; }
+  exit 0
+fi
+
+# --- path 2: generate CA + leaf, save locally and to a new secret ---
+echo "secret $NAMESPACE/$SECRET_NAME not found, generating"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# Build SANs from the comma-separated host list (DNS only).
+SAN=""; i=0
+IFS=',' read -ra HOST_ARR <<< "$HOSTS"
+for h in "${HOST_ARR[@]}"; do
+  i=$((i+1))
+  SAN+="DNS.${i} = ${h}"$'\n'
+done
+
+cat > "$TMP/leaf.cnf" <<EOF
+[req]
+distinguished_name = dn
+req_extensions     = v3
+prompt             = no
+[dn]
+CN = ${HOST_ARR[0]}
+[v3]
+subjectAltName = @san
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+[san]
+${SAN}
+EOF
+
+# CA
+openssl ecparam -name prime256v1 -genkey -noout -out "$TMP/ca.key"
+openssl req -x509 -new -key "$TMP/ca.key" -days "$DAYS" -subj "/O=certgen-ca" -out "$TMP/ca.crt"
+
+# Leaf
+openssl ecparam -name prime256v1 -genkey -noout -out "$TMP/tls.key"
+openssl req -new -key "$TMP/tls.key" -config "$TMP/leaf.cnf" -out "$TMP/tls.csr"
+openssl x509 -req -in "$TMP/tls.csr" -CA "$TMP/ca.crt" -CAkey "$TMP/ca.key" -CAcreateserial \
+  -days "$DAYS" -extensions v3 -extfile "$TMP/leaf.cnf" -out "$TMP/tls.crt"
+
+# Local copy for the pod (filenames mirror the secret keys).
+cp "$TMP/tls.crt" "$OUT_DIR/$CERT_NAME"
+cp "$TMP/tls.key" "$OUT_DIR/$KEY_NAME"
+
+# Persist to a new secret so subsequent pod restarts and the patch step can reuse it.
+kubectl -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
+  --type="$SECRET_TYPE" \
+  --from-file="${CA_NAME}=$TMP/ca.crt" \
+  --from-file="${CERT_NAME}=$TMP/tls.crt" \
+  --from-file="${KEY_NAME}=$TMP/tls.key"

--- a/kube-init-certgen/scripts/certgen-create.sh
+++ b/kube-init-certgen/scripts/certgen-create.sh
@@ -8,7 +8,6 @@ OUT_DIR=""
 CA_NAME="ca"
 CERT_NAME="cert"
 KEY_NAME="key"
-SECRET_TYPE="Opaque"
 DAYS="36500"
 
 usage() {
@@ -21,7 +20,6 @@ Usage: certgen-create.sh [flags]
       --ca-name        Key in the secret for the CA cert (default: ca)
       --cert-name      Key in the secret for the leaf cert (default: cert)
       --key-name       Key in the secret for the leaf key (default: key)
-      --secret-type    Type of the secret (default: Opaque)
       --days           Validity in days (default: 36500 ~= 100y)
 EOF
   exit 2
@@ -36,7 +34,6 @@ while [[ $# -gt 0 ]]; do
     --ca-name)        CA_NAME="$2";     shift 2;;
     --cert-name)      CERT_NAME="$2";   shift 2;;
     --key-name)       KEY_NAME="$2";    shift 2;;
-    --secret-type)    SECRET_TYPE="$2"; shift 2;;
     --days)           DAYS="$2";        shift 2;;
     -h|--help)        usage;;
     *) echo "unknown flag: $1" >&2; usage;;
@@ -103,7 +100,6 @@ cp "$TMP/tls.key" "$OUT_DIR/$KEY_NAME"
 
 # Persist to a new secret so subsequent pod restarts and the patch step can reuse it.
 kubectl -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
-  --type="$SECRET_TYPE" \
   --from-file="${CA_NAME}=$TMP/ca.crt" \
   --from-file="${CERT_NAME}=$TMP/tls.crt" \
   --from-file="${KEY_NAME}=$TMP/tls.key"

--- a/kube-init-certgen/scripts/certgen-patch.sh
+++ b/kube-init-certgen/scripts/certgen-patch.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE=""
+SECRET_NAME=""
+CA_NAME="ca"
+RESOURCE_TYPE=""
+RESOURCE_NAME=""
+RETRIES="60"
+RETRY_INTERVAL="5"
+
+usage() {
+  cat >&2 <<EOF
+Usage: certgen-patch.sh [flags]
+  -n, --namespace        Namespace of the secret (required)
+  -s, --secret-name      Name of the secret holding the CA (required)
+  -c, --ca-name          Key inside the secret holding the CA cert (default: ca)
+  -t, --resource-type    Resource to patch: apiservice | vwc (required)
+  -r, --resource-name    Name of the resource to patch (required)
+      --retries          Max patch attempts (default: 60)
+      --retry-interval   Seconds between attempts (default: 5)
+EOF
+  exit 2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace)      NAMESPACE="$2";      shift 2;;
+    -s|--secret-name)    SECRET_NAME="$2";    shift 2;;
+    -c|--ca-name)        CA_NAME="$2";        shift 2;;
+    -t|--resource-type)  RESOURCE_TYPE="$2";  shift 2;;
+    -r|--resource-name)  RESOURCE_NAME="$2";  shift 2;;
+    --retries)           RETRIES="$2";        shift 2;;
+    --retry-interval)    RETRY_INTERVAL="$2"; shift 2;;
+    -h|--help)           usage;;
+    *) echo "unknown flag: $1" >&2; usage;;
+  esac
+done
+
+[[ -n "$NAMESPACE"     ]] || { echo "--namespace required"     >&2; usage; }
+[[ -n "$SECRET_NAME"   ]] || { echo "--secret-name required"   >&2; usage; }
+[[ -n "$RESOURCE_TYPE" ]] || { echo "--resource-type required" >&2; usage; }
+[[ -n "$RESOURCE_NAME" ]] || { echo "--resource-name required" >&2; usage; }
+
+case "$RESOURCE_TYPE" in
+  apiservice|vwc) ;;
+  *) echo "--resource-type must be 'apiservice' or 'vwc', got '$RESOURCE_TYPE'" >&2; exit 2;;
+esac
+
+CA_BUNDLE="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o json | jq -er --arg k "$CA_NAME" '.data[$k] // empty')"
+[[ -n "$CA_BUNDLE" ]] || { echo "no '$CA_NAME' key in secret $NAMESPACE/$SECRET_NAME" >&2; exit 1; }
+
+patch_once() {
+  case "$RESOURCE_TYPE" in
+    apiservice)
+      kubectl patch apiservice "$RESOURCE_NAME" --type=merge \
+        -p "{\"spec\":{\"caBundle\":\"$CA_BUNDLE\",\"insecureSkipTLSVerify\":false}}"
+      ;;
+    vwc)
+      kubectl patch validatingwebhookconfiguration "$RESOURCE_NAME" --type=json \
+        -p "[{\"op\":\"add\",\"path\":\"/webhooks/0/clientConfig/caBundle\",\"value\":\"$CA_BUNDLE\"}]"
+      ;;
+  esac
+}
+
+for i in $(seq 1 "$RETRIES"); do
+  if patch_once; then
+    exit 0
+  fi
+  echo "patch attempt $i/$RETRIES failed, retrying in ${RETRY_INTERVAL}s" >&2
+  sleep "$RETRY_INTERVAL"
+done
+
+echo "patch failed after $RETRIES attempts" >&2
+exit 1


### PR DESCRIPTION
**Title:** `feat: add kube-init-certgen image`

---

**Summary**

Adds the `kube-init-certgen` image used by the kubescape-operator Helm chart's `initContainer` certificate strategy. The image replaces the third-party `kube-webhook-certgen` Helm hook Jobs with two lightweight bash scripts that run as init containers on the consuming pod, making cert generation GitOps/ArgoCD-safe.

The image is published to `quay.io/kubescape/kube-init-certgen`.

**Contents**

- `Dockerfile` — based on `alpine/k8s:1.36.1` (kubectl + jq included); adds `openssl` via apk. Scripts are copied to `/scripts/` with `WORKDIR /scripts`.
- `scripts/certgen-create.sh` — generates a self-signed CA and leaf certificate (ECDSA P-256) and persists them to a Kubernetes Secret. Idempotent: if the Secret already exists, it materializes the cert/key locally without regenerating.
- `scripts/certgen-patch.sh` — reads the CA bundle from the Secret and patches the `caBundle` field on a `ValidatingWebhookConfiguration` or `APIService` resource. Retries with configurable backoff until the resource is available.

**Used by**

- [kubescape/helm-charts](https://github.com/kubescape/helm-charts) — operator admission webhook (`ValidatingWebhookConfiguration`)
- [kubescape/storage](https://github.com/kubescape/storage) — aggregated API (`APIService`)
