### PR TITLE
chore(deps): bump armoapi-go to v0.0.719

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/operator
 go 1.25.8
 
 require (
-	github.com/armosec/armoapi-go v0.0.714
+	github.com/armosec/armoapi-go v0.0.719
 	github.com/armosec/registryx v0.0.35
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armosec/armoapi-go v0.0.714 h1:gTgv20tUJo4EPWI3LrB56oxcNW7j3vvb5ZoK6kFgMYI=
-github.com/armosec/armoapi-go v0.0.714/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.719 h1:eo35KTOPS0vM3asLfDONwNScZ+1FRhUprpNWs2czXCM=
+github.com/armosec/armoapi-go v0.0.719/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/registryx v0.0.35 h1:fvP5/IZL0+jJUnNXvAj6ohJ6UVHaASVpR/cPLX0I4f0=


### PR DESCRIPTION
## What

Bumps `github.com/armosec/armoapi-go` from **v0.0.673 → v0.0.719**.

## Why

This is the **dep-modernization** step ahead of a rule open-protection watcher. v0.0.719 adds the types that watcher needs:
- `armotypes.OpenMatchers` + `armotypes.UnionOpenProtection`
- the `ProfileDataRequired` schema

The follow-up watcher will resolve `RuntimeRuleAlertBinding` selectors against the rule library (`armosec/rulelibrary`, which requires armoapi ≥ v0.0.719) and publish the union of `profileDataRequired.opens` as a ConfigMap that the storage apiserver reads to keep sensitive-file rules (e.g. R0010) working through profile generalisation. Keeping the version bump as its own PR isolates the dependency change from the feature.

## Scope / cascade

Minimal and additive:
- Only `armoapi-go` moves in `require`; **node-agent (v0.3.38)** and **storage (v0.0.239)** compile unchanged against the newer armoapi — no coordinated bump needed.
- `go.mod` change is one line; `go.sum` changes are 2 lines; no indirect requires added or removed.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean (compiles all packages incl. tests)
- `go test ./watcher/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to latest stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->