### PR TITLE
feat(remediation): add quarantine action (deny-all NetworkPolicy + dry-run)

### DIFF
--- a/mainhandler/actionhandler.go
+++ b/mainhandler/actionhandler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -12,6 +13,7 @@ import (
 	"github.com/kubescape/operator/mainhandler/remediators"
 	"github.com/kubescape/operator/utils"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -80,34 +82,67 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 		helpers.String("dryRun", fmt.Sprintf("%t", dryRun)))
 
 	switch args.Action {
-	case apis.OperatorActionAnnotate:
-		r := registry[apis.OperatorActionAnnotate]
-		plan, err := r.Plan(ctx, remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef})
-		if err != nil {
-			return err
-		}
-		result, err := r.Apply(ctx, plan, dryRun)
-		if err != nil {
-			return err
-		}
-		return actionHandler.recordActionResult(ctx, result)
+	case apis.OperatorActionAnnotate, apis.OperatorActionQuarantine:
+		req := remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef}
+		return actionHandler.applyRemediation(ctx, registry[args.Action], req, dryRun)
 
 	case apis.OperatorActionRevert:
-		// Phase 1: the only applied action is annotate, so revert undoes it.
 		// Pass dryRun so a default (no --confirm) revert previews instead of writing.
-		r := registry[apis.OperatorActionAnnotate]
-		result, err := r.Revert(ctx, target, dryRun)
-		if err != nil {
-			return err
-		}
-		return actionHandler.recordActionResult(ctx, result)
+		return actionHandler.revertTarget(ctx, registry, target, dryRun)
 
-	case apis.OperatorActionQuarantine, apis.OperatorActionCordon:
+	case apis.OperatorActionCordon:
 		return fmt.Errorf("operatorAction: action %q is not implemented yet (planned for a later phase)", args.Action)
 
 	default:
 		return fmt.Errorf("operatorAction: unknown action %q", args.Action)
 	}
+}
+
+// applyRemediation runs a remediator's Plan -> Apply and records the result.
+func (actionHandler *ActionHandler) applyRemediation(ctx context.Context, r remediators.Remediator, req remediators.Request, dryRun bool) error {
+	plan, err := r.Plan(ctx, req)
+	if err != nil {
+		return err
+	}
+	result, err := r.Apply(ctx, plan, dryRun)
+	if err != nil {
+		return err
+	}
+	return actionHandler.recordActionResult(ctx, result)
+}
+
+// revertTarget undoes every reversible action on the target. Each Revert is
+// idempotent — a missing annotation or NetworkPolicy is a no-op — so revert is
+// safe to call without knowing which action was originally applied. A target
+// object that no longer exists (NotFound) is skipped, not treated as an error,
+// so a leftover artifact (e.g. a NetworkPolicy whose workload was deleted) is
+// still cleaned up.
+func (actionHandler *ActionHandler) revertTarget(ctx context.Context, registry map[apis.OperatorActionType]remediators.Remediator, target remediators.Target, dryRun bool) error {
+	reversible := []apis.OperatorActionType{apis.OperatorActionAnnotate, apis.OperatorActionQuarantine}
+	var descriptions []string
+	applied := false
+	for _, action := range reversible {
+		r, ok := registry[action]
+		if !ok {
+			continue
+		}
+		result, err := r.Revert(ctx, target, dryRun)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		descriptions = append(descriptions, result.Description)
+		applied = applied || result.Applied
+	}
+	return actionHandler.recordActionResult(ctx, remediators.Result{
+		Action:      string(apis.OperatorActionRevert),
+		Target:      target,
+		DryRun:      dryRun,
+		Applied:     applied,
+		Description: strings.Join(descriptions, "; "),
+	})
 }
 
 // recordActionResult writes the result to the OperatorCommand status payload

--- a/mainhandler/actionhandler_test.go
+++ b/mainhandler/actionhandler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -21,6 +22,17 @@ import (
 )
 
 func boolPtr(b bool) *bool { return &b }
+
+func deploymentWithSelectorForHandler(ns, name string, selector map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: selector}},
+	}
+}
+
+func networkPolicyForHandler(ns, name string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+}
 
 func newTestConfig(serviceConfig config.Config) config.IConfig {
 	return config.NewOperatorConfig(config.CapabilitiesConfig{}, utilsmetadata.ClusterConfig{}, &beUtils.Credentials{}, serviceConfig)
@@ -178,7 +190,7 @@ func TestHandleOperatorAction_TargetRequired(t *testing.T) {
 func TestHandleOperatorAction_UnimplementedActions(t *testing.T) {
 	client := k8sfake.NewClientset()
 	cfg := newTestConfig(config.Config{Namespace: "kubescape"})
-	for _, action := range []apis.OperatorActionType{apis.OperatorActionQuarantine, apis.OperatorActionCordon} {
+	for _, action := range []apis.OperatorActionType{apis.OperatorActionCordon} {
 		ah := newActionHandlerForTest(t, client, cfg, apis.OperatorActionArgs{
 			Action: action,
 			Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
@@ -187,6 +199,71 @@ func TestHandleOperatorAction_UnimplementedActions(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not implemented yet")
 	}
+}
+
+// quarantine without --confirm must create the deny-all NetworkPolicy as a
+// server-side dry-run, never a real write.
+func TestHandleOperatorAction_QuarantineDefaultsToDryRun(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelectorForHandler("payments", "api", map[string]string{"app": "api"}))
+	var dryRun []string
+	client.PrependReactor("create", "networkpolicies", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		dryRun = action.(clienttesting.CreateActionImpl).CreateOptions.DryRun
+		return false, nil, nil
+	})
+
+	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: apis.OperatorActionQuarantine,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Reason: "C-0016",
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "quarantine without dryRun must default to server-side dry-run")
+}
+
+// quarantine --confirm writes the NetworkPolicy isolating the workload's pods.
+func TestHandleOperatorAction_QuarantineConfirmWrites(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelectorForHandler("payments", "api", map[string]string{"app": "api"}))
+	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: apis.OperatorActionQuarantine,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "api"}, got.Spec.PodSelector.MatchLabels)
+}
+
+// A quarantine target in an excluded namespace must be rejected before any write.
+func TestHandleOperatorAction_QuarantineExcludedNamespace(t *testing.T) {
+	client := k8sfake.NewClientset()
+	cfg := newTestConfig(config.Config{Namespace: "kubescape", ExcludeNamespaces: []string{"kube-system"}})
+	ah := newActionHandlerForTest(t, client, cfg, apis.OperatorActionArgs{
+		Action: apis.OperatorActionQuarantine,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "kube-system", Name: "api"},
+		DryRun: boolPtr(false),
+	})
+	err := ah.handleOperatorAction(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "excluded from remediation")
+}
+
+// revert undoes quarantine (deletes the NetworkPolicy) even when the workload was
+// never annotated — without the caller naming which action to undo.
+func TestHandleOperatorAction_RevertDeletesQuarantine(t *testing.T) {
+	np := networkPolicyForHandler("payments", "kubescape-quarantine-api")
+	client := k8sfake.NewClientset(np)
+	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: apis.OperatorActionRevert,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	_, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	assert.Error(t, err, "revert must delete the quarantine NetworkPolicy")
 }
 
 func TestHandleOperatorAction_UnknownAction(t *testing.T) {

--- a/mainhandler/actionhandler_test.go
+++ b/mainhandler/actionhandler_test.go
@@ -231,7 +231,7 @@ func TestHandleOperatorAction_QuarantineConfirmWrites(t *testing.T) {
 	})
 
 	require.NoError(t, ah.handleOperatorAction(context.Background()))
-	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-deployment-api", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"app": "api"}, got.Spec.PodSelector.MatchLabels)
 }
@@ -248,12 +248,18 @@ func TestHandleOperatorAction_QuarantineExcludedNamespace(t *testing.T) {
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "excluded from remediation")
+
+	// The rejection must happen before any cluster write — no NetworkPolicy may
+	// have been created in the excluded namespace.
+	nps, listErr := client.NetworkingV1().NetworkPolicies("kube-system").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, listErr)
+	assert.Empty(t, nps.Items, "excluded namespace must be rejected before any NetworkPolicy write")
 }
 
 // revert undoes quarantine (deletes the NetworkPolicy) even when the workload was
 // never annotated — without the caller naming which action to undo.
 func TestHandleOperatorAction_RevertDeletesQuarantine(t *testing.T) {
-	np := networkPolicyForHandler("payments", "kubescape-quarantine-api")
+	np := networkPolicyForHandler("payments", "kubescape-quarantine-deployment-api")
 	client := k8sfake.NewClientset(np)
 	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: apis.OperatorActionRevert,
@@ -262,7 +268,7 @@ func TestHandleOperatorAction_RevertDeletesQuarantine(t *testing.T) {
 	})
 
 	require.NoError(t, ah.handleOperatorAction(context.Background()))
-	_, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	_, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-deployment-api", metav1.GetOptions{})
 	assert.Error(t, err, "revert must delete the quarantine NetworkPolicy")
 }
 

--- a/mainhandler/remediators/annotate.go
+++ b/mainhandler/remediators/annotate.go
@@ -73,9 +73,28 @@ func (r *AnnotateRemediator) Apply(ctx context.Context, p Plan, dryRun bool) (Re
 // Apply, dryRun=true issues a server-side dry-run (validated against admission,
 // never persisted); only dryRun=false performs a real write — so the
 // safe-by-default contract is honored for revert too.
+//
+// The contract's revert verb undoes every reversible action without naming which
+// one was applied, so revert runs annotate even on a workload that was only
+// quarantined. To keep the audit trail honest, a workload carrying none of the
+// remediation annotations is reported as a no-op ("nothing to revert",
+// Applied=false) rather than claiming annotations were removed.
 func (r *AnnotateRemediator) Revert(ctx context.Context, t Target, dryRun bool) (Result, error) {
 	if err := validateTarget(t); err != nil {
 		return Result{}, err
+	}
+	annotations, err := r.getAnnotations(ctx, t)
+	if err != nil {
+		return Result{}, err
+	}
+	if !hasAnyKey(annotations, AnnotationRemediated, AnnotationReason, AnnotationFindingRef) {
+		return Result{
+			Action:      string(apis.OperatorActionRevert),
+			Target:      t,
+			DryRun:      dryRun,
+			Applied:     false,
+			Description: fmt.Sprintf("no kubescape remediation annotations on %s; nothing to revert", t),
+		}, nil
 	}
 	// A JSON merge patch deletes a key by setting it to null.
 	patch, err := annotationPatch(map[string]interface{}{
@@ -107,6 +126,40 @@ func (r *AnnotateRemediator) desiredAnnotations(req Request) map[string]string {
 		annotations[AnnotationFindingRef] = req.FindingRef
 	}
 	return annotations
+}
+
+// getAnnotations reads the live target's annotations so Revert can tell whether
+// there is anything to undo. A NotFound is returned to the caller (the action
+// handler skips a target that no longer exists).
+func (r *AnnotateRemediator) getAnnotations(ctx context.Context, t Target) (map[string]string, error) {
+	switch strings.ToLower(t.Kind) {
+	case "deployment":
+		o, err := r.client.AppsV1().Deployments(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return o.Annotations, nil
+	case "statefulset":
+		o, err := r.client.AppsV1().StatefulSets(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return o.Annotations, nil
+	case "daemonset":
+		o, err := r.client.AppsV1().DaemonSets(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return o.Annotations, nil
+	case "pod":
+		o, err := r.client.CoreV1().Pods(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return o.Annotations, nil
+	default:
+		return nil, fmt.Errorf("annotate: unsupported target kind %q (supported: Deployment, StatefulSet, DaemonSet, Pod)", t.Kind)
+	}
 }
 
 // patch applies a JSON merge patch to the target object using the typed client
@@ -162,6 +215,16 @@ func toInterfaceMap(in map[string]string) map[string]interface{} {
 		out[k] = v
 	}
 	return out
+}
+
+// hasAnyKey reports whether m contains at least one of keys.
+func hasAnyKey(m map[string]string, keys ...string) bool {
+	for _, k := range keys {
+		if _, ok := m[k]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func validateTarget(t Target) error {

--- a/mainhandler/remediators/annotate_test.go
+++ b/mainhandler/remediators/annotate_test.go
@@ -145,6 +145,26 @@ func TestAnnotateRevert(t *testing.T) {
 	assert.Equal(t, "keep-me", got.Annotations["unrelated"], "unrelated annotations must be preserved")
 }
 
+// revert runs on every target regardless of which action was applied, so a
+// workload that was never annotated must be reported as a no-op ("nothing to
+// revert", Applied=false) instead of claiming annotations were removed — and it
+// must not issue a patch.
+func TestAnnotateRevertNoAnnotationsIsNoop(t *testing.T) {
+	client := k8sfake.NewClientset(annotatedDeployment("payments", "api", map[string]string{"unrelated": "keep-me"}))
+	patched := false
+	client.PrependReactor("patch", "deployments", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		patched = true
+		return false, nil, nil
+	})
+	r := NewAnnotateRemediator(client)
+
+	res, err := r.Revert(context.Background(), Target{Kind: "Deployment", Namespace: "payments", Name: "api"}, false)
+	require.NoError(t, err)
+	assert.False(t, res.Applied, "nothing to revert")
+	assert.Contains(t, res.Description, "nothing to revert")
+	assert.False(t, patched, "revert must not patch a workload with no kubescape annotations")
+}
+
 // A dry-run revert must request server-side dry-run and never persist, mirroring
 // Apply — so the safe-by-default contract holds for revert too.
 func TestAnnotateRevertDryRun(t *testing.T) {

--- a/mainhandler/remediators/quarantine.go
+++ b/mainhandler/remediators/quarantine.go
@@ -1,0 +1,213 @@
+package remediators
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/armosec/armoapi-go/apis"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// LabelQuarantine marks the deny-all NetworkPolicy created by the quarantine
+	// action, so it can be found and removed on revert.
+	LabelQuarantine = "kubescape.io/quarantine"
+	// AnnotationQuarantineTarget records, on the NetworkPolicy, the workload it
+	// isolates — part of the audit trail.
+	AnnotationQuarantineTarget = "kubescape.io/quarantine-target"
+
+	// quarantineNPPrefix is the deterministic name prefix of the deny-all
+	// NetworkPolicy, so revert can locate it from the target name alone.
+	quarantineNPPrefix = "kubescape-quarantine-"
+	// maxNameLen is the Kubernetes object-name length limit.
+	maxNameLen = 253
+)
+
+// QuarantineRemediator isolates a workload by creating a deny-all NetworkPolicy
+// that selects the workload's pods (both ingress and egress denied). It does
+// not mutate or recreate the pods, so container state is preserved for forensic
+// investigation (the design's resolved default; scale-to-zero is a future,
+// explicit opt-in). Revert deletes the NetworkPolicy.
+type QuarantineRemediator struct {
+	client kubernetes.Interface
+}
+
+// NewQuarantineRemediator returns a quarantine remediator backed by client.
+func NewQuarantineRemediator(client kubernetes.Interface) *QuarantineRemediator {
+	return &QuarantineRemediator{client: client}
+}
+
+// Plan reads the target workload's pod selector from the live object and
+// computes the deny-all NetworkPolicy without creating it.
+func (r *QuarantineRemediator) Plan(ctx context.Context, req Request) (Plan, error) {
+	if err := validateTarget(req.Target); err != nil {
+		return Plan{}, err
+	}
+	selector, err := r.resolvePodSelector(ctx, req.Target)
+	if err != nil {
+		return Plan{}, err
+	}
+	np := r.buildNetworkPolicy(req, selector)
+	body, err := json.Marshal(np)
+	if err != nil {
+		return Plan{}, err
+	}
+	return Plan{
+		Action:      string(apis.OperatorActionQuarantine),
+		Target:      req.Target,
+		Description: fmt.Sprintf("deny-all NetworkPolicy %q isolating %s (podSelector %v)", np.Name, req.Target, selector),
+		Patch:       string(body),
+	}, nil
+}
+
+// Apply creates the planned deny-all NetworkPolicy. With dryRun=true it is sent
+// as a server-side dry-run (validated against admission, never persisted); only
+// dryRun=false performs a real write. An existing policy is treated as success
+// (the workload is already isolated by a prior quarantine).
+func (r *QuarantineRemediator) Apply(ctx context.Context, p Plan, dryRun bool) (Result, error) {
+	var np networkingv1.NetworkPolicy
+	if err := json.Unmarshal([]byte(p.Patch), &np); err != nil {
+		return Result{}, fmt.Errorf("quarantine: failed to decode planned NetworkPolicy: %w", err)
+	}
+	opts := metav1.CreateOptions{}
+	if dryRun {
+		opts.DryRun = []string{metav1.DryRunAll}
+	}
+	_, err := r.client.NetworkingV1().NetworkPolicies(np.Namespace).Create(ctx, &np, opts)
+	switch {
+	case err == nil, apierrors.IsAlreadyExists(err):
+		// created, or already isolated by a prior quarantine — both are success.
+	default:
+		return Result{}, fmt.Errorf("quarantine: failed to create NetworkPolicy %q: %w", np.Name, err)
+	}
+	return Result{
+		Action:      p.Action,
+		Target:      p.Target,
+		DryRun:      dryRun,
+		Applied:     !dryRun,
+		Description: p.Description,
+	}, nil
+}
+
+// Revert deletes the deny-all NetworkPolicy that quarantined the target. A
+// missing policy is treated as success (nothing to undo). Like Apply, dryRun=true
+// issues a server-side dry-run delete, so the safe-by-default contract holds for
+// revert too.
+func (r *QuarantineRemediator) Revert(ctx context.Context, t Target, dryRun bool) (Result, error) {
+	if err := validateTarget(t); err != nil {
+		return Result{}, err
+	}
+	name := quarantineNPName(t.Name)
+	opts := metav1.DeleteOptions{}
+	if dryRun {
+		opts.DryRun = []string{metav1.DryRunAll}
+	}
+	err := r.client.NetworkingV1().NetworkPolicies(t.Namespace).Delete(ctx, name, opts)
+	applied := !dryRun
+	desc := fmt.Sprintf("deleted quarantine NetworkPolicy %q in namespace %q", name, t.Namespace)
+	switch {
+	case apierrors.IsNotFound(err):
+		applied = false
+		desc = fmt.Sprintf("no quarantine NetworkPolicy %q in namespace %q; nothing to revert", name, t.Namespace)
+	case err != nil:
+		return Result{}, fmt.Errorf("quarantine: failed to delete NetworkPolicy %q: %w", name, err)
+	}
+	return Result{
+		Action:      string(apis.OperatorActionRevert),
+		Target:      t,
+		DryRun:      dryRun,
+		Applied:     applied,
+		Description: desc,
+	}, nil
+}
+
+// resolvePodSelector returns the labels that select the target's running pods,
+// read from the live object so quarantine isolates the existing pods without
+// recreating them.
+func (r *QuarantineRemediator) resolvePodSelector(ctx context.Context, t Target) (map[string]string, error) {
+	var labels map[string]string
+	switch strings.ToLower(t.Kind) {
+	case "deployment":
+		o, err := r.client.AppsV1().Deployments(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		labels = matchLabels(o.Spec.Selector)
+	case "statefulset":
+		o, err := r.client.AppsV1().StatefulSets(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		labels = matchLabels(o.Spec.Selector)
+	case "daemonset":
+		o, err := r.client.AppsV1().DaemonSets(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		labels = matchLabels(o.Spec.Selector)
+	case "pod":
+		o, err := r.client.CoreV1().Pods(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		labels = o.Labels
+	default:
+		return nil, fmt.Errorf("quarantine: unsupported target kind %q (supported: Deployment, StatefulSet, DaemonSet, Pod)", t.Kind)
+	}
+	if len(labels) == 0 {
+		return nil, fmt.Errorf("quarantine: %s has no pod selector labels to isolate; cannot build a NetworkPolicy", t)
+	}
+	return labels, nil
+}
+
+// buildNetworkPolicy assembles the deny-all NetworkPolicy: it selects the
+// target's pods and declares both policy types with no allow rules, which denies
+// all ingress and egress. Audit context is recorded in its labels/annotations.
+func (r *QuarantineRemediator) buildNetworkPolicy(req Request, selector map[string]string) *networkingv1.NetworkPolicy {
+	annotations := map[string]string{AnnotationQuarantineTarget: req.Target.String()}
+	if req.Reason != "" {
+		annotations[AnnotationReason] = req.Reason
+	}
+	if req.FindingRef != "" {
+		annotations[AnnotationFindingRef] = req.FindingRef
+	}
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        quarantineNPName(req.Target.Name),
+			Namespace:   req.Target.Namespace,
+			Labels:      map[string]string{LabelQuarantine: "true"},
+			Annotations: annotations,
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{MatchLabels: selector},
+			// Both policy types selected with no ingress/egress rules => deny all.
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+		},
+	}
+}
+
+func matchLabels(sel *metav1.LabelSelector) map[string]string {
+	if sel == nil {
+		return nil
+	}
+	return sel.MatchLabels
+}
+
+// quarantineNPName derives the deterministic deny-all NetworkPolicy name for a
+// target so revert can find it from the target name alone, kept within the
+// object-name length limit and with no invalid trailing separators.
+func quarantineNPName(target string) string {
+	name := quarantineNPPrefix + target
+	if len(name) > maxNameLen {
+		name = strings.TrimRight(name[:maxNameLen], "-.")
+	}
+	return name
+}

--- a/mainhandler/remediators/quarantine.go
+++ b/mainhandler/remediators/quarantine.go
@@ -2,6 +2,8 @@ package remediators
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -60,7 +62,7 @@ func (r *QuarantineRemediator) Plan(ctx context.Context, req Request) (Plan, err
 	return Plan{
 		Action:      string(apis.OperatorActionQuarantine),
 		Target:      req.Target,
-		Description: fmt.Sprintf("deny-all NetworkPolicy %q isolating %s (podSelector %v)", np.Name, req.Target, selector),
+		Description: fmt.Sprintf("deny-all NetworkPolicy %q isolating %s (podSelector %s)", np.Name, req.Target, metav1.FormatLabelSelector(selector)),
 		Patch:       string(body),
 	}, nil
 }
@@ -102,7 +104,7 @@ func (r *QuarantineRemediator) Revert(ctx context.Context, t Target, dryRun bool
 	if err := validateTarget(t); err != nil {
 		return Result{}, err
 	}
-	name := quarantineNPName(t.Name)
+	name := quarantineNPName(t)
 	opts := metav1.DeleteOptions{}
 	if dryRun {
 		opts.DryRun = []string{metav1.DryRunAll}
@@ -126,49 +128,51 @@ func (r *QuarantineRemediator) Revert(ctx context.Context, t Target, dryRun bool
 	}, nil
 }
 
-// resolvePodSelector returns the labels that select the target's running pods,
-// read from the live object so quarantine isolates the existing pods without
-// recreating them.
-func (r *QuarantineRemediator) resolvePodSelector(ctx context.Context, t Target) (map[string]string, error) {
-	var labels map[string]string
+// resolvePodSelector returns the label selector that selects the target's
+// running pods, read from the live object so quarantine isolates the existing
+// pods without recreating them. The full selector (both matchLabels and
+// matchExpressions) is preserved so workloads using set-based selectors are
+// isolated correctly.
+func (r *QuarantineRemediator) resolvePodSelector(ctx context.Context, t Target) (*metav1.LabelSelector, error) {
+	var selector *metav1.LabelSelector
 	switch strings.ToLower(t.Kind) {
 	case "deployment":
 		o, err := r.client.AppsV1().Deployments(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-		labels = matchLabels(o.Spec.Selector)
+		selector = o.Spec.Selector
 	case "statefulset":
 		o, err := r.client.AppsV1().StatefulSets(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-		labels = matchLabels(o.Spec.Selector)
+		selector = o.Spec.Selector
 	case "daemonset":
 		o, err := r.client.AppsV1().DaemonSets(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-		labels = matchLabels(o.Spec.Selector)
+		selector = o.Spec.Selector
 	case "pod":
 		o, err := r.client.CoreV1().Pods(t.Namespace).Get(ctx, t.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-		labels = o.Labels
+		selector = &metav1.LabelSelector{MatchLabels: o.Labels}
 	default:
 		return nil, fmt.Errorf("quarantine: unsupported target kind %q (supported: Deployment, StatefulSet, DaemonSet, Pod)", t.Kind)
 	}
-	if len(labels) == 0 {
+	if selector == nil || (len(selector.MatchLabels) == 0 && len(selector.MatchExpressions) == 0) {
 		return nil, fmt.Errorf("quarantine: %s has no pod selector labels to isolate; cannot build a NetworkPolicy", t)
 	}
-	return labels, nil
+	return selector, nil
 }
 
 // buildNetworkPolicy assembles the deny-all NetworkPolicy: it selects the
 // target's pods and declares both policy types with no allow rules, which denies
 // all ingress and egress. Audit context is recorded in its labels/annotations.
-func (r *QuarantineRemediator) buildNetworkPolicy(req Request, selector map[string]string) *networkingv1.NetworkPolicy {
+func (r *QuarantineRemediator) buildNetworkPolicy(req Request, selector *metav1.LabelSelector) *networkingv1.NetworkPolicy {
 	annotations := map[string]string{AnnotationQuarantineTarget: req.Target.String()}
 	if req.Reason != "" {
 		annotations[AnnotationReason] = req.Reason
@@ -178,13 +182,13 @@ func (r *QuarantineRemediator) buildNetworkPolicy(req Request, selector map[stri
 	}
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        quarantineNPName(req.Target.Name),
+			Name:        quarantineNPName(req.Target),
 			Namespace:   req.Target.Namespace,
 			Labels:      map[string]string{LabelQuarantine: "true"},
 			Annotations: annotations,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{MatchLabels: selector},
+			PodSelector: *selector,
 			// Both policy types selected with no ingress/egress rules => deny all.
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeIngress,
@@ -194,20 +198,18 @@ func (r *QuarantineRemediator) buildNetworkPolicy(req Request, selector map[stri
 	}
 }
 
-func matchLabels(sel *metav1.LabelSelector) map[string]string {
-	if sel == nil {
-		return nil
-	}
-	return sel.MatchLabels
-}
-
 // quarantineNPName derives the deterministic deny-all NetworkPolicy name for a
-// target so revert can find it from the target name alone, kept within the
-// object-name length limit and with no invalid trailing separators.
-func quarantineNPName(target string) string {
-	name := quarantineNPPrefix + target
-	if len(name) > maxNameLen {
-		name = strings.TrimRight(name[:maxNameLen], "-.")
+// target so revert can find it from the target identity alone. The name is keyed
+// on both kind and name so different kinds sharing a name (e.g. Deployment/api
+// and StatefulSet/api) do not collide on — or delete — each other's policy. It
+// is kept within the object-name length limit; when truncation is needed a short
+// hash of the full identity is appended to keep distinct targets distinct.
+func quarantineNPName(t Target) string {
+	base := quarantineNPPrefix + strings.ToLower(t.Kind) + "-" + t.Name
+	if len(base) <= maxNameLen {
+		return base
 	}
-	return name
+	sum := sha256.Sum256([]byte(t.String()))
+	suffix := "-" + hex.EncodeToString(sum[:])[:10]
+	return strings.TrimRight(base[:maxNameLen-len(suffix)], "-.") + suffix
 }

--- a/mainhandler/remediators/quarantine.go
+++ b/mainhandler/remediators/quarantine.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -28,6 +29,14 @@ const (
 	quarantineNPPrefix = "kubescape-quarantine-"
 	// maxNameLen is the Kubernetes object-name length limit.
 	maxNameLen = 253
+
+	// quarantineCaveat records the two operational preconditions of a deny-all
+	// NetworkPolicy in the plan/result audit trail: it is enforced only by a CNI
+	// that implements NetworkPolicy (on a non-enforcing CNI the policy is created
+	// but silently does nothing), and it isolates every pod matching the
+	// workload's selector labels, which can be broader than the target itself when
+	// other workloads share those labels.
+	quarantineCaveat = "isolation is enforced only by a NetworkPolicy-capable CNI and applies to all pods matching the selector"
 )
 
 // QuarantineRemediator isolates a workload by creating a deny-all NetworkPolicy
@@ -35,6 +44,22 @@ const (
 // not mutate or recreate the pods, so container state is preserved for forensic
 // investigation (the design's resolved default; scale-to-zero is a future,
 // explicit opt-in). Revert deletes the NetworkPolicy.
+//
+// Isolation semantics and preconditions (surfaced in the plan/result via
+// quarantineCaveat):
+//   - CNI enforcement: a NetworkPolicy only isolates traffic on a CNI that
+//     enforces NetworkPolicy. On a non-enforcing CNI the policy is created but
+//     has no effect; the action still reports success because the desired object
+//     was applied — enforcement is a cluster property the operator cannot verify.
+//   - Blast radius: the policy selects by the workload's selector labels, so it
+//     isolates every pod matching them — including pods owned by other workloads
+//     that reuse the same labels (blue/green, canary, a second Deployment reusing
+//     "app="). Quarantine assumes the selector identifies the intended pods.
+//   - Pod targets: a NetworkPolicy selects pods by label, not by name. A
+//     controller-managed pod's labels are shared by every replica of its template
+//     (pod-template-hash, etc.), so quarantining a Pod isolates the whole
+//     ReplicaSet/template, not the single named pod. Single-pod isolation is not
+//     achievable with a NetworkPolicy.
 type QuarantineRemediator struct {
 	client kubernetes.Interface
 }
@@ -62,15 +87,18 @@ func (r *QuarantineRemediator) Plan(ctx context.Context, req Request) (Plan, err
 	return Plan{
 		Action:      string(apis.OperatorActionQuarantine),
 		Target:      req.Target,
-		Description: fmt.Sprintf("deny-all NetworkPolicy %q isolating %s (podSelector %s)", np.Name, req.Target, metav1.FormatLabelSelector(selector)),
+		Description: fmt.Sprintf("deny-all NetworkPolicy %q isolating %s (podSelector %s); %s", np.Name, req.Target, metav1.FormatLabelSelector(selector), quarantineCaveat),
 		Patch:       string(body),
 	}, nil
 }
 
 // Apply creates the planned deny-all NetworkPolicy. With dryRun=true it is sent
 // as a server-side dry-run (validated against admission, never persisted); only
-// dryRun=false performs a real write. An existing policy is treated as success
-// (the workload is already isolated by a prior quarantine).
+// dryRun=false performs a real write. If a policy already exists (a prior
+// quarantine), it is reconciled to the freshly planned spec so that a selector
+// that drifted since the first quarantine (the workload was edited/redeployed)
+// still isolates the currently-running pods, rather than leaving a stale policy
+// in place while reporting success.
 func (r *QuarantineRemediator) Apply(ctx context.Context, p Plan, dryRun bool) (Result, error) {
 	var np networkingv1.NetworkPolicy
 	if err := json.Unmarshal([]byte(p.Patch), &np); err != nil {
@@ -82,8 +110,14 @@ func (r *QuarantineRemediator) Apply(ctx context.Context, p Plan, dryRun bool) (
 	}
 	_, err := r.client.NetworkingV1().NetworkPolicies(np.Namespace).Create(ctx, &np, opts)
 	switch {
-	case err == nil, apierrors.IsAlreadyExists(err):
-		// created, or already isolated by a prior quarantine — both are success.
+	case err == nil:
+		// created — the workload is now isolated.
+	case apierrors.IsAlreadyExists(err):
+		// A prior quarantine policy exists; reconcile it to the planned spec so a
+		// drifted selector does not silently leave the running pods unisolated.
+		if err := r.reconcile(ctx, &np, dryRun); err != nil {
+			return Result{}, err
+		}
 	default:
 		return Result{}, fmt.Errorf("quarantine: failed to create NetworkPolicy %q: %w", np.Name, err)
 	}
@@ -94,6 +128,37 @@ func (r *QuarantineRemediator) Apply(ctx context.Context, p Plan, dryRun bool) (
 		Applied:     !dryRun,
 		Description: p.Description,
 	}, nil
+}
+
+// reconcile brings an already-existing quarantine NetworkPolicy in line with the
+// desired spec, updating it when the selector or audit metadata drifted since it
+// was created. An identical policy is left untouched (nothing to do). A policy
+// that vanished between the failed Create and this Get (raced with a revert) is
+// a clean no-op.
+func (r *QuarantineRemediator) reconcile(ctx context.Context, desired *networkingv1.NetworkPolicy, dryRun bool) error {
+	existing, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("quarantine: failed to read existing NetworkPolicy %q: %w", desired.Name, err)
+	}
+	if reflect.DeepEqual(existing.Spec, desired.Spec) &&
+		reflect.DeepEqual(existing.Labels, desired.Labels) &&
+		reflect.DeepEqual(existing.Annotations, desired.Annotations) {
+		return nil // already isolating the current pods.
+	}
+	existing.Spec = desired.Spec
+	existing.Labels = desired.Labels
+	existing.Annotations = desired.Annotations
+	opts := metav1.UpdateOptions{}
+	if dryRun {
+		opts.DryRun = []string{metav1.DryRunAll}
+	}
+	if _, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Update(ctx, existing, opts); err != nil {
+		return fmt.Errorf("quarantine: failed to reconcile NetworkPolicy %q: %w", desired.Name, err)
+	}
+	return nil
 }
 
 // Revert deletes the deny-all NetworkPolicy that quarantined the target. A
@@ -159,6 +224,11 @@ func (r *QuarantineRemediator) resolvePodSelector(ctx context.Context, t Target)
 		if err != nil {
 			return nil, err
 		}
+		// The pod's full label set is used as the selector. For a
+		// controller-managed pod those labels (pod-template-hash, etc.) are shared
+		// by every replica of the template, so this isolates the whole
+		// ReplicaSet/template — a NetworkPolicy cannot select one pod by name. See
+		// the type doc for the isolation-semantics rationale.
 		selector = &metav1.LabelSelector{MatchLabels: o.Labels}
 	default:
 		return nil, fmt.Errorf("quarantine: unsupported target kind %q (supported: Deployment, StatefulSet, DaemonSet, Pod)", t.Kind)

--- a/mainhandler/remediators/quarantine_test.go
+++ b/mainhandler/remediators/quarantine_test.go
@@ -55,7 +55,7 @@ func TestQuarantinePlan(t *testing.T) {
 	assert.Equal(t, "Deployment/payments/api", plan.Target.String())
 
 	np := decodeNP(t, plan.Patch)
-	assert.Equal(t, "kubescape-quarantine-api", np.Name)
+	assert.Equal(t, "kubescape-quarantine-deployment-api", np.Name)
 	assert.Equal(t, "payments", np.Namespace)
 	assert.Equal(t, "true", np.Labels[LabelQuarantine])
 	assert.Equal(t, "Deployment/payments/api", np.Annotations[AnnotationQuarantineTarget])
@@ -64,6 +64,30 @@ func TestQuarantinePlan(t *testing.T) {
 	assert.ElementsMatch(t, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, np.Spec.PolicyTypes)
 	assert.Empty(t, np.Spec.Ingress, "deny-all means no ingress rules")
 	assert.Empty(t, np.Spec.Egress, "deny-all means no egress rules")
+}
+
+// A workload using set-based selectors (matchExpressions) must have that full
+// selector carried into the NetworkPolicy, not silently dropped.
+func TestQuarantinePlanPreservesMatchExpressions(t *testing.T) {
+	expr := []metav1.LabelSelectorRequirement{{
+		Key:      "tier",
+		Operator: metav1.LabelSelectorOpIn,
+		Values:   []string{"backend", "api"},
+	}}
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"},
+		Spec: appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{
+			MatchLabels:      map[string]string{"app": "api"},
+			MatchExpressions: expr,
+		}},
+	}
+	r := NewQuarantineRemediator(k8sfake.NewClientset(deploy))
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+
+	np := decodeNP(t, plan.Patch)
+	assert.Equal(t, map[string]string{"app": "api"}, np.Spec.PodSelector.MatchLabels)
+	assert.Equal(t, expr, np.Spec.PodSelector.MatchExpressions, "set-based selector requirements must be preserved")
 }
 
 func TestQuarantinePlanRequiresSelectorLabels(t *testing.T) {
@@ -96,7 +120,7 @@ func TestQuarantineApplyConfirm(t *testing.T) {
 	assert.True(t, res.Applied)
 	assert.Empty(t, dryRun, "a confirmed apply must not request server-side dry-run")
 
-	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-deployment-api", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"app": "api"}, got.Spec.PodSelector.MatchLabels)
 	assert.ElementsMatch(t, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, got.Spec.PolicyTypes)
@@ -128,7 +152,7 @@ func TestQuarantineApplyPodUsesPodLabels(t *testing.T) {
 	_, err = r.Apply(context.Background(), plan, false)
 	require.NoError(t, err)
 
-	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api-0", metav1.GetOptions{})
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-pod-api-0", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"app": "api", "pod-template-hash": "abc"}, got.Spec.PodSelector.MatchLabels)
 }
@@ -149,7 +173,7 @@ func TestQuarantineApplyAlreadyExists(t *testing.T) {
 
 func TestQuarantineRevert(t *testing.T) {
 	existing := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-api", Labels: map[string]string{LabelQuarantine: "true"}},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-deployment-api", Labels: map[string]string{LabelQuarantine: "true"}},
 	}
 	client := k8sfake.NewClientset(existing)
 	r := NewQuarantineRemediator(client)
@@ -159,7 +183,7 @@ func TestQuarantineRevert(t *testing.T) {
 	assert.True(t, res.Applied)
 	assert.Equal(t, string(apis.OperatorActionRevert), res.Action)
 
-	_, err = client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	_, err = client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-deployment-api", metav1.GetOptions{})
 	assert.Error(t, err, "the quarantine NetworkPolicy must be deleted")
 }
 
@@ -174,7 +198,7 @@ func TestQuarantineRevertNotFound(t *testing.T) {
 
 func TestQuarantineRevertDryRun(t *testing.T) {
 	existing := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-api"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-deployment-api"},
 	}
 	client := k8sfake.NewClientset(existing)
 	var dryRun []string
@@ -190,9 +214,18 @@ func TestQuarantineRevertDryRun(t *testing.T) {
 
 func TestQuarantineNPNameTruncation(t *testing.T) {
 	long := strings.Repeat("a", 300)
-	name := quarantineNPName(long)
+	name := quarantineNPName(Target{Kind: "Deployment", Namespace: "payments", Name: long})
 	assert.LessOrEqual(t, len(name), maxNameLen)
 	assert.True(t, strings.HasPrefix(name, quarantineNPPrefix))
+}
+
+// Different kinds sharing a name must not collide on the same NetworkPolicy,
+// otherwise reverting one target would delete another's policy.
+func TestQuarantineNPNameUniquePerKind(t *testing.T) {
+	deploy := quarantineNPName(Target{Kind: "Deployment", Namespace: "payments", Name: "api"})
+	sts := quarantineNPName(Target{Kind: "StatefulSet", Namespace: "payments", Name: "api"})
+	assert.NotEqual(t, deploy, sts)
+	assert.Equal(t, "kubescape-quarantine-deployment-api", deploy)
 }
 
 func decodeNP(t *testing.T, body string) *networkingv1.NetworkPolicy {

--- a/mainhandler/remediators/quarantine_test.go
+++ b/mainhandler/remediators/quarantine_test.go
@@ -1,0 +1,203 @@
+package remediators
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+// captureCreateDryRun records the DryRun option of the next create on the given
+// resource; the fake tracker ignores server-side dry-run (it always persists),
+// so the only reliable assertion is the option actually sent on the wire.
+func captureCreateDryRun(client *k8sfake.Clientset, resource string, out *[]string) {
+	client.PrependReactor("create", resource, func(action clienttesting.Action) (bool, runtime.Object, error) {
+		*out = action.(clienttesting.CreateActionImpl).CreateOptions.DryRun
+		return false, nil, nil // not handled: let the default tracker apply
+	})
+}
+
+func captureDeleteDryRun(client *k8sfake.Clientset, resource string, out *[]string) {
+	client.PrependReactor("delete", resource, func(action clienttesting.Action) (bool, runtime.Object, error) {
+		*out = action.(clienttesting.DeleteActionImpl).DeleteOptions.DryRun
+		return false, nil, nil
+	})
+}
+
+func deploymentWithSelector(ns, name string, selector map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+		Spec:       appsv1.DeploymentSpec{Selector: &metav1.LabelSelector{MatchLabels: selector}},
+	}
+}
+
+func TestQuarantinePlan(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", map[string]string{"app": "api"}))
+	r := NewQuarantineRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{
+		Target:     Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Reason:     "C-0016",
+		FindingRef: "workloadconfigurationscansummaries/payments/api",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(apis.OperatorActionQuarantine), plan.Action)
+	assert.Equal(t, "Deployment/payments/api", plan.Target.String())
+
+	np := decodeNP(t, plan.Patch)
+	assert.Equal(t, "kubescape-quarantine-api", np.Name)
+	assert.Equal(t, "payments", np.Namespace)
+	assert.Equal(t, "true", np.Labels[LabelQuarantine])
+	assert.Equal(t, "Deployment/payments/api", np.Annotations[AnnotationQuarantineTarget])
+	assert.Equal(t, "C-0016", np.Annotations[AnnotationReason])
+	assert.Equal(t, map[string]string{"app": "api"}, np.Spec.PodSelector.MatchLabels)
+	assert.ElementsMatch(t, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, np.Spec.PolicyTypes)
+	assert.Empty(t, np.Spec.Ingress, "deny-all means no ingress rules")
+	assert.Empty(t, np.Spec.Egress, "deny-all means no egress rules")
+}
+
+func TestQuarantinePlanRequiresSelectorLabels(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", nil))
+	r := NewQuarantineRemediator(client)
+	_, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no pod selector labels")
+}
+
+func TestQuarantinePlanUnsupportedKind(t *testing.T) {
+	r := NewQuarantineRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Service", Namespace: "payments", Name: "api"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported target kind")
+}
+
+func TestQuarantineApplyConfirm(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", map[string]string{"app": "api"}))
+	var dryRun []string
+	captureCreateDryRun(client, "networkpolicies", &dryRun)
+
+	r := NewQuarantineRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+
+	res, err := r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	assert.False(t, res.DryRun)
+	assert.True(t, res.Applied)
+	assert.Empty(t, dryRun, "a confirmed apply must not request server-side dry-run")
+
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "api"}, got.Spec.PodSelector.MatchLabels)
+	assert.ElementsMatch(t, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}, got.Spec.PolicyTypes)
+}
+
+func TestQuarantineApplyDryRun(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", map[string]string{"app": "api"}))
+	var dryRun []string
+	captureCreateDryRun(client, "networkpolicies", &dryRun)
+
+	r := NewQuarantineRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+
+	res, err := r.Apply(context.Background(), plan, true)
+	require.NoError(t, err)
+	assert.True(t, res.DryRun)
+	assert.False(t, res.Applied)
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a dry-run apply must request server-side dry-run")
+}
+
+func TestQuarantineApplyPodUsesPodLabels(t *testing.T) {
+	client := k8sfake.NewClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api-0", Labels: map[string]string{"app": "api", "pod-template-hash": "abc"}},
+	})
+	r := NewQuarantineRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Pod", Namespace: "payments", Name: "api-0"}})
+	require.NoError(t, err)
+	_, err = r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "api", "pod-template-hash": "abc"}, got.Spec.PodSelector.MatchLabels)
+}
+
+// A second quarantine on an already-isolated workload must succeed (idempotent).
+func TestQuarantineApplyAlreadyExists(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", map[string]string{"app": "api"}))
+	r := NewQuarantineRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+
+	_, err = r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	res, err := r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	assert.True(t, res.Applied)
+}
+
+func TestQuarantineRevert(t *testing.T) {
+	existing := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-api", Labels: map[string]string{LabelQuarantine: "true"}},
+	}
+	client := k8sfake.NewClientset(existing)
+	r := NewQuarantineRemediator(client)
+
+	res, err := r.Revert(context.Background(), Target{Kind: "Deployment", Namespace: "payments", Name: "api"}, false)
+	require.NoError(t, err)
+	assert.True(t, res.Applied)
+	assert.Equal(t, string(apis.OperatorActionRevert), res.Action)
+
+	_, err = client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-api", metav1.GetOptions{})
+	assert.Error(t, err, "the quarantine NetworkPolicy must be deleted")
+}
+
+// Reverting a target that was never quarantined is a no-op success.
+func TestQuarantineRevertNotFound(t *testing.T) {
+	r := NewQuarantineRemediator(k8sfake.NewClientset())
+	res, err := r.Revert(context.Background(), Target{Kind: "Deployment", Namespace: "payments", Name: "api"}, false)
+	require.NoError(t, err)
+	assert.False(t, res.Applied, "nothing to revert")
+	assert.Contains(t, res.Description, "nothing to revert")
+}
+
+func TestQuarantineRevertDryRun(t *testing.T) {
+	existing := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-api"},
+	}
+	client := k8sfake.NewClientset(existing)
+	var dryRun []string
+	captureDeleteDryRun(client, "networkpolicies", &dryRun)
+	r := NewQuarantineRemediator(client)
+
+	res, err := r.Revert(context.Background(), Target{Kind: "Deployment", Namespace: "payments", Name: "api"}, true)
+	require.NoError(t, err)
+	assert.True(t, res.DryRun)
+	assert.False(t, res.Applied)
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a dry-run revert must request server-side dry-run")
+}
+
+func TestQuarantineNPNameTruncation(t *testing.T) {
+	long := strings.Repeat("a", 300)
+	name := quarantineNPName(long)
+	assert.LessOrEqual(t, len(name), maxNameLen)
+	assert.True(t, strings.HasPrefix(name, quarantineNPPrefix))
+}
+
+func decodeNP(t *testing.T, body string) *networkingv1.NetworkPolicy {
+	t.Helper()
+	var np networkingv1.NetworkPolicy
+	require.NoError(t, json.Unmarshal([]byte(body), &np))
+	return &np
+}

--- a/mainhandler/remediators/quarantine_test.go
+++ b/mainhandler/remediators/quarantine_test.go
@@ -171,6 +171,65 @@ func TestQuarantineApplyAlreadyExists(t *testing.T) {
 	assert.True(t, res.Applied)
 }
 
+// Re-quarantining after the workload's selector changed must reconcile the
+// existing policy to the new selector, not leave the stale one in place (which
+// would report success while the running pods stay unisolated).
+func TestQuarantineApplyReconcilesSelectorDrift(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", map[string]string{"app": "api"}))
+	r := NewQuarantineRemediator(client)
+
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+	_, err = r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+
+	// The workload is edited/redeployed with a new selector.
+	_, err = client.AppsV1().Deployments("payments").Update(context.Background(),
+		deploymentWithSelector("payments", "api", map[string]string{"app": "api", "track": "blue"}), metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	plan, err = r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+	res, err := r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	assert.True(t, res.Applied)
+
+	got, err := client.NetworkingV1().NetworkPolicies("payments").Get(context.Background(), "kubescape-quarantine-deployment-api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "api", "track": "blue"}, got.Spec.PodSelector.MatchLabels,
+		"an already-existing policy must be reconciled to the current selector")
+}
+
+// Reconciling an already-correct policy must issue the update as a server-side
+// dry-run when dryRun is set, honoring the safe-by-default contract.
+func TestQuarantineApplyReconcileHonorsDryRun(t *testing.T) {
+	client := k8sfake.NewClientset(deploymentWithSelector("payments", "api", map[string]string{"app": "api"}))
+	r := NewQuarantineRemediator(client)
+
+	plan, err := r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+	_, err = r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+
+	_, err = client.AppsV1().Deployments("payments").Update(context.Background(),
+		deploymentWithSelector("payments", "api", map[string]string{"app": "api", "track": "blue"}), metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	var dryRun []string
+	client.PrependReactor("update", "networkpolicies", func(action clienttesting.Action) (bool, runtime.Object, error) {
+		dryRun = action.(clienttesting.UpdateActionImpl).UpdateOptions.DryRun
+		return false, nil, nil
+	})
+
+	plan, err = r.Plan(context.Background(), Request{Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"}})
+	require.NoError(t, err)
+	res, err := r.Apply(context.Background(), plan, true)
+	require.NoError(t, err)
+	assert.True(t, res.DryRun)
+	assert.False(t, res.Applied)
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a dry-run reconcile must request server-side dry-run")
+}
+
 func TestQuarantineRevert(t *testing.T) {
 	existing := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "kubescape-quarantine-deployment-api", Labels: map[string]string{LabelQuarantine: "true"}},

--- a/mainhandler/remediators/remediator.go
+++ b/mainhandler/remediators/remediator.go
@@ -73,11 +73,12 @@ type Remediator interface {
 	Revert(ctx context.Context, t Target, dryRun bool) (Result, error)
 }
 
-// NewRegistry builds the set of remediators backed by the given client. Phase 1
-// ships annotate only; quarantine/cordon are added in later phases by extending
-// this map.
+// NewRegistry builds the set of remediators backed by the given client. New
+// actions are added by extending this map; the command pipeline does not change.
+// cordon is added in a later phase.
 func NewRegistry(client kubernetes.Interface) map[apis.OperatorActionType]Remediator {
 	return map[apis.OperatorActionType]Remediator{
-		apis.OperatorActionAnnotate: NewAnnotateRemediator(client),
+		apis.OperatorActionAnnotate:   NewAnnotateRemediator(client),
+		apis.OperatorActionQuarantine: NewQuarantineRemediator(client),
 	}
 }


### PR DESCRIPTION

**Related issue:** [kubescape/kubescape#1770 — Kubescape CLI control over cluster operations](https://github.com/kubescape/kubescape/issues/1770)
**Design:** [kubescape/designs-and-proposals#5 — Kubescape CLI Control over Cluster Operations](https://github.com/kubescape/designs-and-proposals/pull/5) (merged)
**Contract:** [armosec/armoapi-go#655 — `operatorAction` command contract](https://github.com/armosec/armoapi-go/pull/655) (merged, `v0.0.720`)
**Builds on:** [kubescape/operator#383 — Phase 1 (annotate + dry-run)](https://github.com/kubescape/operator/pull/383) (merged) · RBAC from [kubescape/helm-charts#855](https://github.com/kubescape/helm-charts/pull/855) (merged)


## Overview

This is **Phase 2** of the merged design: it teaches the operator to execute the
`quarantine` action. Phase 1 ([#383](https://github.com/kubescape/operator/pull/383))
shipped `annotate` and the extensible `Remediator` framework; this PR plugs the
next action into that framework with **no pipeline or transport changes** — a new
`Remediator` added to the registry, exactly as Phase 1 was designed to allow.

`quarantine` isolates a workload by creating a **deny-all `NetworkPolicy`** that
selects the workload's pods (both ingress and egress denied). Per the design's
[resolved open question #3](https://github.com/kubescape/designs-and-proposals/pull/5),
the default is **non-destructive**: the pods are **not** mutated or recreated, so
container state (memory, process trees) is preserved for forensic investigation.
Scale-to-zero / container-stop remains a future, explicit opt-in.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

## What changed

- **`mainhandler/remediators/quarantine.go`** *(new)* — `QuarantineRemediator`
  implementing `Plan`/`Apply`/`Revert`:
  - **`Plan`** reads the target's pod selector from the **live** object
    (`Deployment`/`StatefulSet`/`DaemonSet` `spec.selector.matchLabels`, or a
    `Pod`'s own labels) and computes a deny-all `NetworkPolicy` without touching
    the cluster. Reading the live selector isolates the *existing* pods without
    recreating them.
  - **`Apply`** creates the `NetworkPolicy` (deterministic name
    `kubescape-quarantine-<target>`); server-side dry-run when `dryRun=true`;
    idempotent (`AlreadyExists` → success, the workload is already isolated).
  - **`Revert`** deletes that `NetworkPolicy`; a missing policy is a clean no-op
    success; honors server-side dry-run.
  - Audit context (`reason`, `findingRef`, the target) is recorded on the
    `NetworkPolicy`'s labels/annotations.
- **`mainhandler/remediators/remediator.go`** — register `quarantine` in
  `NewRegistry` (one line; `cordon` remains the only stubbed action).
- **`mainhandler/actionhandler.go`** — dispatch `quarantine` through a shared
  `applyRemediation` (Plan → Apply → record), and **extend `revert`** to undo
  *every* reversible action on the target (annotate + quarantine), idempotently.
  This is required because the contract's `revert` verb does not name which action
  it undoes; each `Revert` is a safe no-op when there is nothing to undo, and a
  target object that no longer exists (`NotFound`) is skipped so a leftover
  `NetworkPolicy` is still cleaned up.
- **Tests** — `mainhandler/remediators/quarantine_test.go` (11) and additions to
  `mainhandler/actionhandler_test.go` (5); the existing "unimplemented actions"
  test is narrowed to `cordon` only.

## Safe-by-default behaviour (unchanged from Phase 1)

- **Dry-run is the default.** A command without an explicit `dryRun=false` (the
  CLI's `--confirm`) creates the `NetworkPolicy` with `metav1.DryRunAll` — validated
  against admission, never persisted.
- **Namespace safety rail.** Targets in excluded/protected namespaces
  (`config.SkipNamespace`) are rejected before any client call.
- **No default-install power.** Creating `NetworkPolicy` requires the opt-in
  mutating RBAC from [helm-charts#855](https://github.com/kubescape/helm-charts/pull/855)
  (`capabilities.remediation=enable`), which the default install does not grant —
  so a mistakenly-triggered quarantine fails closed with `Forbidden`, mutating
  nothing. **No new RBAC is needed**: #855 already provisioned
  `networking.k8s.io/networkpolicies` `create/delete/get/list`.
- **No new contract.** `armoapi-go v0.0.720` already carries the `quarantine` verb;
  this PR needs no `armoapi-go` change.

## Additional Information

- **Why deny-all NetworkPolicy and not scale-to-zero.** The design resolved this:
  scaling to zero destroys the container and wipes forensic evidence. A deny-all
  policy cuts the workload off the network while leaving it running for
  investigation. Destructive modes are a later, explicit opt-in.
- **Selector source.** The `NetworkPolicy.spec.podSelector` is the workload's own
  pod-selector labels, read live at `Plan` time. A workload with no selector labels
  is rejected with a clear error rather than producing a policy that would match
  every pod in the namespace.
- **Idempotency & revert symmetry.** Re-quarantining an already-isolated workload
  succeeds; `revert` is safe to call without knowing what was applied and cleans up
  even if the original workload was deleted out from under it.
- **Scope.** Explicit-target `quarantine` only. Findings-driven selector targeting
  (`--control` / `--min-severity`, reading the stored scan-result CRDs) and the
  multi-result status aggregation it requires are the focused next operator PR;
  `cordon` and operator-native auto-remediation are Phase 3.

## How to Test

```bash
go build ./...                       # clean
go vet ./mainhandler/...             # clean
go test ./mainhandler/...            # pass (remediators + mainhandler)
```

Manual end-to-end (cluster with the operator installed and
`capabilities.remediation=enable`), via the CLI once the paired `kubescape`
subcommand lands, or by writing an `OperatorCommand` CRD:

```bash
# after a confirmed quarantine of Deployment payments/api:
kubectl get networkpolicy -n payments kubescape-quarantine-api -o yaml
kubectl get events -n payments --field-selector reason=KubescapeRemediation
```

The `NetworkPolicy` should select the deployment's pod labels with
`policyTypes: [Ingress, Egress]` and no allow rules.

## Related issues/PRs

- Implements (in part): #1770 — CLI control over cluster operations (Phase 2).
- Design: [kubescape/designs-and-proposals#5](https://github.com/kubescape/designs-and-proposals/pull/5) (merged).
- Contract: [armosec/armoapi-go#655](https://github.com/armosec/armoapi-go/pull/655) (merged, `v0.0.720`).
- Builds on: [kubescape/operator#383](https://github.com/kubescape/operator/pull/383) (merged) — Phase 1 framework.
- RBAC/install: [kubescape/helm-charts#855](https://github.com/kubescape/helm-charts/pull/855) (merged) — already grants the NetworkPolicy RBAC.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new quarantine action that isolates workloads by creating a deny-all network policy.
  * Revert now attempts to undo both annotation and quarantine actions when available.
* **Bug Fixes**
  * Improved revert behavior to handle missing resources gracefully.
  * Quarantine actions now support dry-run and confirm modes consistently.
* **Tests**
  * Added coverage for quarantine planning, apply/revert flows, excluded namespaces, and revert behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->