### PR TITLE
operator: findings-driven targeting for `operatorAction` (resolve `selector` from stored scan results)

### DIFF
--- a/mainhandler/actionhandler.go
+++ b/mainhandler/actionhandler.go
@@ -3,6 +3,7 @@ package mainhandler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -46,22 +47,61 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 		return fmt.Errorf("operatorAction: ttl/auto-revert is not supported yet (later phase); omit ttl")
 	}
 
-	// Phase 1 ships explicit-target actions only. Findings-driven Selector
-	// targeting (reading the stored scan-result CRDs) arrives in phase 2.
-	if args.Target == nil {
-		if args.Selector != nil {
-			return fmt.Errorf("operatorAction: findings-driven selector targeting is not supported yet (phase 2); provide an explicit target")
+	// Resolve the target set: an explicit Target, or a findings-driven Selector
+	// that reads the stored configuration-scan summaries (no re-scan). Exactly
+	// one of the two must be provided.
+	targets, err := actionHandler.resolveTargets(ctx, args)
+	if err != nil {
+		return err
+	}
+
+	dryRun := args.IsDryRun()
+	registry := remediators.NewRegistry(actionHandler.k8sAPI.KubernetesClient)
+
+	// A single target (explicit, or a selector that resolved to one) returns its
+	// error verbatim. A multi-target selector runs every target and aggregates
+	// failures so one bad workload does not abandon the rest.
+	if len(targets) == 1 {
+		return actionHandler.handleActionOnTarget(ctx, args, targets[0], registry, dryRun)
+	}
+	var errs []error
+	for _, target := range targets {
+		if err := actionHandler.handleActionOnTarget(ctx, args, target, registry, dryRun); err != nil {
+			errs = append(errs, fmt.Errorf("target %s: %w", target, err))
 		}
-		return fmt.Errorf("operatorAction: a target is required")
 	}
+	return errors.Join(errs...)
+}
 
-	target := remediators.Target{
-		Kind:      args.Target.Kind,
-		Namespace: args.Target.Namespace,
-		Name:      args.Target.Name,
+// resolveTargets returns the concrete objects the action operates on. An
+// explicit Target is used as-is; a Selector is resolved against stored findings.
+// A selector that matches nothing is an error, not a silent no-op, so the caller
+// learns the action had no effect.
+func (actionHandler *ActionHandler) resolveTargets(ctx context.Context, args apis.OperatorActionArgs) ([]remediators.Target, error) {
+	if args.Target != nil {
+		return []remediators.Target{{
+			Kind:      args.Target.Kind,
+			Namespace: args.Target.Namespace,
+			Name:      args.Target.Name,
+		}}, nil
 	}
+	if args.Selector != nil {
+		targets, err := actionHandler.resolveSelectorTargets(ctx, args.Selector)
+		if err != nil {
+			return nil, err
+		}
+		if len(targets) == 0 {
+			return nil, fmt.Errorf("operatorAction: selector matched no workloads (control=%q minSeverity=%q)", args.Selector.Control, args.Selector.MinSeverity)
+		}
+		return targets, nil
+	}
+	return nil, fmt.Errorf("operatorAction: a target is required")
+}
 
-	// All Phase-1 target kinds are namespaced. Require the namespace up front so
+// handleActionOnTarget enforces the per-target safety rails and dispatches the
+// action to the matching remediator. It runs once per resolved target.
+func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, args apis.OperatorActionArgs, target remediators.Target, registry map[apis.OperatorActionType]remediators.Remediator, dryRun bool) error {
+	// All current target kinds are namespaced. Require the namespace up front so
 	// the excluded-namespace rail below is actually enforced, instead of an empty
 	// namespace slipping past it and failing late at the API server.
 	if remediators.IsNamespacedKind(target.Kind) && target.Namespace == "" {
@@ -72,9 +112,6 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 	if target.Namespace != "" && actionHandler.config.SkipNamespace(target.Namespace) {
 		return fmt.Errorf("operatorAction: namespace %q is excluded from remediation", target.Namespace)
 	}
-
-	dryRun := args.IsDryRun()
-	registry := remediators.NewRegistry(actionHandler.k8sAPI.KubernetesClient)
 
 	logger.L().Info("handling operator action",
 		helpers.String("action", string(args.Action)),

--- a/mainhandler/actionhandler_test.go
+++ b/mainhandler/actionhandler_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/kubescape/operator/config"
 	"github.com/kubescape/operator/mainhandler/remediators"
 	"github.com/kubescape/operator/utils"
+	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	kssc "github.com/kubescape/storage/pkg/generated/clientset/versioned"
+	kssfake "github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,11 +43,17 @@ func newTestConfig(serviceConfig config.Config) config.IConfig {
 
 func newActionHandlerForTest(t *testing.T, client kubernetes.Interface, cfg config.IConfig, args apis.OperatorActionArgs) *ActionHandler {
 	t.Helper()
+	return newActionHandlerForTestWithStorage(t, client, kssfake.NewSimpleClientset(), cfg, args)
+}
+
+func newActionHandlerForTestWithStorage(t *testing.T, client kubernetes.Interface, storageClient kssc.Interface, cfg config.IConfig, args apis.OperatorActionArgs) *ActionHandler {
+	t.Helper()
 	argsMap, err := args.ToArgs()
 	require.NoError(t, err)
 	return &ActionHandler{
-		k8sAPI: utils.NewK8sInterfaceFake(client),
-		config: cfg,
+		k8sAPI:          utils.NewK8sInterfaceFake(client),
+		ksStorageClient: storageClient,
+		config:          cfg,
 		sessionObj: &utils.SessionObj{
 			Command: &apis.Command{CommandName: apis.TypeOperatorAction, Args: argsMap},
 		},
@@ -166,15 +175,81 @@ func TestHandleOperatorAction_ExcludedNamespaceRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "excluded from remediation")
 }
 
-func TestHandleOperatorAction_SelectorTargetingNotYetSupported(t *testing.T) {
-	client := k8sfake.NewClientset()
-	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+// A findings-driven selector annotates exactly the workloads that fail the
+// requested control — and leaves the ones that pass it untouched.
+func TestHandleOperatorAction_SelectorAnnotatesMatchingWorkloads(t *testing.T) {
+	client := k8sfake.NewClientset(
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "web"}},
+	)
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+		scanSummary("payments", "Deployment", "web", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": passedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{}),
+	)
+
+	ah := newActionHandlerForTestWithStorage(t, client, storageClient, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action:   apis.OperatorActionAnnotate,
-		Selector: &apis.OperatorActionSelector{Control: "C-0016", MinSeverity: "High"},
+		Selector: &apis.OperatorActionSelector{Control: "C-0016"},
+		Reason:   "C-0016",
+		DryRun:   boolPtr(false),
 	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+
+	api, err := client.AppsV1().Deployments("payments").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", api.Annotations[remediators.AnnotationRemediated], "workload failing C-0016 must be annotated")
+
+	web, err := client.AppsV1().Deployments("payments").Get(context.Background(), "web", metav1.GetOptions{})
+	require.NoError(t, err)
+	_, ok := web.Annotations[remediators.AnnotationRemediated]
+	assert.False(t, ok, "workload passing C-0016 must be left untouched")
+}
+
+// A selector without --confirm must default to a server-side dry-run for every
+// matched workload, never a real write.
+func TestHandleOperatorAction_SelectorDefaultsToDryRun(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	var dryRun []string
+	capturePatchDryRun(client, "deployments", &dryRun)
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+	)
+
+	ah := newActionHandlerForTestWithStorage(t, client, storageClient, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action:   apis.OperatorActionAnnotate,
+		Selector: &apis.OperatorActionSelector{Control: "C-0016"},
+		// DryRun intentionally nil
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a selector action without dryRun must default to server-side dry-run")
+}
+
+// A selector that matches no stored finding is an explicit error, not a silent
+// no-op, so the caller learns the action had no effect.
+func TestHandleOperatorAction_SelectorMatchesNothing(t *testing.T) {
+	client := k8sfake.NewClientset()
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "web", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": passedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{}),
+	)
+
+	ah := newActionHandlerForTestWithStorage(t, client, storageClient, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action:   apis.OperatorActionAnnotate,
+		Selector: &apis.OperatorActionSelector{Control: "C-0016"},
+	})
+
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "selector targeting is not supported yet")
+	assert.Contains(t, err.Error(), "matched no workloads")
 }
 
 func TestHandleOperatorAction_TargetRequired(t *testing.T) {

--- a/mainhandler/findings.go
+++ b/mainhandler/findings.go
@@ -1,0 +1,179 @@
+package mainhandler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	reporthandlingapis "github.com/kubescape/opa-utils/reporthandling/apis"
+	"github.com/kubescape/operator/mainhandler/remediators"
+	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// severity ranks order findings from most to least severe so a MinSeverity
+// filter ("act on High and above") is a simple >= comparison. Unknown is the
+// weakest non-zero rank; 0 means "unrecognized severity".
+const (
+	rankUnknown  = 1
+	rankLow      = 2
+	rankMedium   = 3
+	rankHigh     = 4
+	rankCritical = 5
+)
+
+// severityRank maps a severity string (case-insensitive) to its rank. The bool
+// is false for an unrecognized severity so callers can reject a bad MinSeverity
+// rather than silently matching nothing.
+func severityRank(severity string) (int, bool) {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case "critical":
+		return rankCritical, true
+	case "high":
+		return rankHigh, true
+	case "medium":
+		return rankMedium, true
+	case "low":
+		return rankLow, true
+	case "unknown":
+		return rankUnknown, true
+	default:
+		return 0, false
+	}
+}
+
+// resolveSelectorTargets turns a findings-driven Selector into a concrete set of
+// workload targets by reading the stored configuration-scan summaries
+// (workloadconfigurationscansummaries in spdx.softwarecomposition.kubescape.io).
+// No re-scan happens: it acts on findings already in the cluster.
+//
+// A summary matches when it fails the requested Control and/or carries a failing
+// finding at or above MinSeverity (see summaryMatchesSelector). Targets in
+// excluded/protected namespaces and non-remediable kinds are dropped here so
+// they never reach a remediator, and duplicates are collapsed.
+func (actionHandler *ActionHandler) resolveSelectorTargets(ctx context.Context, selector *apis.OperatorActionSelector) ([]remediators.Target, error) {
+	// An empty selector would otherwise match every workload; require an explicit
+	// axis so "remediate everything" can never be the accidental default.
+	if selector.Control == "" && selector.MinSeverity == "" {
+		return nil, fmt.Errorf("operatorAction: selector requires at least one of 'control' or 'minSeverity'")
+	}
+
+	minRank := 0
+	if selector.MinSeverity != "" {
+		r, ok := severityRank(selector.MinSeverity)
+		if !ok {
+			return nil, fmt.Errorf("operatorAction: invalid minSeverity %q (want Critical|High|Medium|Low|Unknown)", selector.MinSeverity)
+		}
+		minRank = r
+	}
+
+	if actionHandler.ksStorageClient == nil {
+		return nil, fmt.Errorf("operatorAction: findings-driven targeting requires the storage client, which is not configured")
+	}
+
+	// namespace "" lists configuration-scan summaries across all namespaces.
+	summaries, err := actionHandler.ksStorageClient.SpdxV1beta1().WorkloadConfigurationScanSummaries("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("operatorAction: failed to list configuration scan summaries: %w", err)
+	}
+
+	var targets []remediators.Target
+	seen := make(map[string]struct{})
+	for i := range summaries.Items {
+		summary := &summaries.Items[i]
+		if !summaryMatchesSelector(summary, selector.Control, minRank) {
+			continue
+		}
+		target, ok := targetFromSummaryLabels(summary.Labels)
+		if !ok {
+			continue
+		}
+		// The remediators only act on namespaced workload kinds; skip anything
+		// else (e.g. CronJob) rather than failing the whole batch later.
+		if !remediators.IsNamespacedKind(target.Kind) {
+			continue
+		}
+		// Protected/excluded namespaces are never remediated, even by a selector.
+		if actionHandler.config.SkipNamespace(target.Namespace) {
+			continue
+		}
+		key := target.String()
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+// summaryMatchesSelector reports whether a configuration-scan summary satisfies
+// the selector. With a Control set, the named control must be present and
+// failing (and, if MinSeverity is also set, at or above that severity). With
+// only MinSeverity set, any failing finding at or above that severity matches.
+func summaryMatchesSelector(summary *spdxv1beta1.WorkloadConfigurationScanSummary, control string, minRank int) bool {
+	if control != "" {
+		c, ok := findFailedControl(summary, control)
+		if !ok {
+			return false
+		}
+		if minRank > 0 {
+			if r, _ := severityRank(c.Severity.Severity); r < minRank {
+				return false
+			}
+		}
+		return true
+	}
+	return summaryHasFailingSeverityAtLeast(summary, minRank)
+}
+
+// findFailedControl looks up a control by ID in the summary and returns it only
+// if it failed. The controls map is keyed by control ID by convention, but the
+// ControlID field is matched too so a differently-keyed map still resolves.
+func findFailedControl(summary *spdxv1beta1.WorkloadConfigurationScanSummary, controlID string) (spdxv1beta1.ScannedControlSummary, bool) {
+	want := strings.ToLower(strings.TrimSpace(controlID))
+	for key, c := range summary.Spec.Controls {
+		if strings.ToLower(key) != want && strings.ToLower(c.ControlID) != want {
+			continue
+		}
+		if strings.EqualFold(c.Status.Status, string(reporthandlingapis.StatusFailed)) {
+			return c, true
+		}
+	}
+	return spdxv1beta1.ScannedControlSummary{}, false
+}
+
+// summaryHasFailingSeverityAtLeast reports whether the summary has at least one
+// failed control at or above minRank. The Severities block counts failed
+// controls per severity, so a non-zero count at a qualifying rank is a match.
+func summaryHasFailingSeverityAtLeast(summary *spdxv1beta1.WorkloadConfigurationScanSummary, minRank int) bool {
+	sev := summary.Spec.Severities
+	byRank := map[int]int64{
+		rankCritical: sev.Critical,
+		rankHigh:     sev.High,
+		rankMedium:   sev.Medium,
+		rankLow:      sev.Low,
+		rankUnknown:  sev.Unknown,
+	}
+	for rank, count := range byRank {
+		if rank >= minRank && count > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// targetFromSummaryLabels extracts the workload identity a scan summary was
+// produced for from its kubescape.io/workload-* labels. It reports false when
+// the identifying labels are missing so an unidentifiable summary is skipped.
+func targetFromSummaryLabels(labels map[string]string) (remediators.Target, bool) {
+	kind := labels[helpers.KindMetadataKey]
+	name := labels[helpers.NameMetadataKey]
+	namespace := labels[helpers.NamespaceMetadataKey]
+	if kind == "" || name == "" {
+		return remediators.Target{}, false
+	}
+	return remediators.Target{Kind: kind, Namespace: namespace, Name: name}, true
+}

--- a/mainhandler/findings_test.go
+++ b/mainhandler/findings_test.go
@@ -1,0 +1,227 @@
+package mainhandler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/kubescape/k8s-interface/instanceidhandler/v1/helpers"
+	"github.com/kubescape/operator/config"
+	"github.com/kubescape/operator/mainhandler/remediators"
+	spdxv1beta1 "github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	kssc "github.com/kubescape/storage/pkg/generated/clientset/versioned"
+	kssfake "github.com/kubescape/storage/pkg/generated/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// scanSummary builds a WorkloadConfigurationScanSummary for a workload, carrying
+// the kubescape.io/workload-* labels the resolver reads to recover the target.
+func scanSummary(ns, kind, name string, controls map[string]spdxv1beta1.ScannedControlSummary, sev spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary) *spdxv1beta1.WorkloadConfigurationScanSummary {
+	return &spdxv1beta1.WorkloadConfigurationScanSummary{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns,
+			Name:      kind + "-" + name,
+			Labels: map[string]string{
+				helpers.KindMetadataKey:      kind,
+				helpers.NameMetadataKey:      name,
+				helpers.NamespaceMetadataKey: ns,
+			},
+		},
+		Spec: spdxv1beta1.WorkloadConfigurationScanSummarySpec{
+			Controls:   controls,
+			Severities: sev,
+		},
+	}
+}
+
+func failedControl(id, severity string) spdxv1beta1.ScannedControlSummary {
+	return spdxv1beta1.ScannedControlSummary{
+		ControlID: id,
+		Severity:  spdxv1beta1.ControlSeverity{Severity: severity},
+		Status:    spdxv1beta1.ScannedControlStatus{Status: "failed"},
+	}
+}
+
+func passedControl(id, severity string) spdxv1beta1.ScannedControlSummary {
+	return spdxv1beta1.ScannedControlSummary{
+		ControlID: id,
+		Severity:  spdxv1beta1.ControlSeverity{Severity: severity},
+		Status:    spdxv1beta1.ScannedControlStatus{Status: "passed"},
+	}
+}
+
+func newResolver(storageClient kssc.Interface, cfg config.IConfig) *ActionHandler {
+	return &ActionHandler{ksStorageClient: storageClient, config: cfg}
+}
+
+func TestSeverityRank(t *testing.T) {
+	cases := []struct {
+		in    string
+		want  int
+		valid bool
+	}{
+		{"Critical", rankCritical, true},
+		{"high", rankHigh, true},
+		{"  Medium  ", rankMedium, true},
+		{"low", rankLow, true},
+		{"Unknown", rankUnknown, true},
+		{"bogus", 0, false},
+		{"", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := severityRank(c.in)
+		assert.Equal(t, c.valid, ok, "validity for %q", c.in)
+		assert.Equal(t, c.want, got, "rank for %q", c.in)
+	}
+	// Ordering the whole feature depends on: Critical > High > Medium > Low > Unknown.
+	assert.Greater(t, rankCritical, rankHigh)
+	assert.Greater(t, rankHigh, rankMedium)
+	assert.Greater(t, rankMedium, rankLow)
+	assert.Greater(t, rankLow, rankUnknown)
+}
+
+func TestResolveSelectorTargets_ByControl(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+		scanSummary("payments", "Deployment", "web", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": passedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{}),
+		scanSummary("payments", "Deployment", "worker", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0055": failedControl("C-0055", "Medium"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{Medium: 1}),
+	)
+	ah := newResolver(storageClient, newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016"})
+	require.NoError(t, err)
+	assert.Equal(t, []remediators.Target{{Kind: "Deployment", Namespace: "payments", Name: "api"}}, targets,
+		"only the workload failing C-0016 must be selected")
+}
+
+func TestResolveSelectorTargets_ByMinSeverity(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "critical-api", nil,
+			spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{Critical: 2}),
+		scanSummary("payments", "Deployment", "high-api", nil,
+			spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+		scanSummary("payments", "Deployment", "low-only", nil,
+			spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{Low: 3}),
+	)
+	ah := newResolver(storageClient, newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{MinSeverity: "High"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []remediators.Target{
+		{Kind: "Deployment", Namespace: "payments", Name: "critical-api"},
+		{Kind: "Deployment", Namespace: "payments", Name: "high-api"},
+	}, targets, "MinSeverity=High must match Critical and High, exclude Low-only")
+}
+
+// Control + MinSeverity together: the matched control must itself meet the
+// severity floor, even if the control failed.
+func TestResolveSelectorTargets_ControlBelowMinSeverityExcluded(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "Medium"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{Medium: 1}),
+	)
+	ah := newResolver(storageClient, newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016", MinSeverity: "High"})
+	require.NoError(t, err)
+	assert.Empty(t, targets, "a failing control below MinSeverity must not match")
+}
+
+// The #1 correctness trap: an empty selector must match nothing, not everything.
+func TestResolveSelectorTargets_EmptySelectorRejected(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "api", nil,
+			spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+	)
+	ah := newResolver(storageClient, newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	_, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one of 'control' or 'minSeverity'")
+}
+
+func TestResolveSelectorTargets_InvalidMinSeverityRejected(t *testing.T) {
+	ah := newResolver(kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}))
+	_, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{MinSeverity: "banana"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid minSeverity")
+}
+
+func TestResolveSelectorTargets_SkipsExcludedNamespace(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("kube-system", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+	)
+	cfg := newTestConfig(config.Config{Namespace: "kubescape", ExcludeNamespaces: []string{"kube-system"}})
+	ah := newResolver(storageClient, cfg)
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016"})
+	require.NoError(t, err)
+	assert.Empty(t, targets, "a match in an excluded namespace must be dropped")
+}
+
+// Config-scan summaries exist for kinds the remediators cannot act on (e.g.
+// CronJob); those must not become targets.
+func TestResolveSelectorTargets_SkipsUnsupportedKind(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummary("payments", "CronJob", "nightly", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+	)
+	ah := newResolver(storageClient, newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016"})
+	require.NoError(t, err)
+	assert.Empty(t, targets, "a non-remediable kind must be skipped")
+}
+
+func TestResolveSelectorTargets_SkipsSummaryMissingLabels(t *testing.T) {
+	// A summary that fails the control but lacks the identifying labels can't be
+	// resolved to a target and must be skipped, not panic.
+	unlabeled := &spdxv1beta1.WorkloadConfigurationScanSummary{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "orphan"},
+		Spec: spdxv1beta1.WorkloadConfigurationScanSummarySpec{
+			Controls: map[string]spdxv1beta1.ScannedControlSummary{"C-0016": failedControl("C-0016", "High")},
+		},
+	}
+	ah := newResolver(kssfake.NewSimpleClientset(unlabeled), newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016"})
+	require.NoError(t, err)
+	assert.Empty(t, targets)
+}
+
+// Two summaries for the same workload (e.g. re-scans) must collapse to one target.
+func TestResolveSelectorTargets_Dedup(t *testing.T) {
+	storageClient := kssfake.NewSimpleClientset(
+		scanSummaryNamed("payments", "Deployment", "api", "summary-1", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}),
+		scanSummaryNamed("payments", "Deployment", "api", "summary-2", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}),
+	)
+	ah := newResolver(storageClient, newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016"})
+	require.NoError(t, err)
+	assert.Equal(t, []remediators.Target{{Kind: "Deployment", Namespace: "payments", Name: "api"}}, targets)
+}
+
+// scanSummaryNamed is scanSummary with an explicit CR name so two summaries for
+// the same workload can coexist in the fake store.
+func scanSummaryNamed(ns, kind, name, crName string, controls map[string]spdxv1beta1.ScannedControlSummary) *spdxv1beta1.WorkloadConfigurationScanSummary {
+	s := scanSummary(ns, kind, name, controls, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{})
+	s.Name = crName
+	return s
+}

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -48,6 +48,7 @@ type ActionHandler struct {
 	sessionObj             *utils.SessionObj
 	config                 config.IConfig
 	k8sAPI                 *k8sinterface.KubernetesApi
+	ksStorageClient        kssc.Interface
 	commandResponseChannel *commandResponseChannelData
 	wlid                   string
 	exporter               exporters.Exporter
@@ -96,10 +97,11 @@ func NewMainHandler(config config.IConfig, k8sAPI *k8sinterface.KubernetesApi, e
 }
 
 // CreateWebSocketHandler Create ws-handler obj
-func NewActionHandler(config config.IConfig, k8sAPI *k8sinterface.KubernetesApi, sessionObj *utils.SessionObj, commandResponseChannel *commandResponseChannelData, exporter exporters.Exporter) *ActionHandler {
+func NewActionHandler(config config.IConfig, k8sAPI *k8sinterface.KubernetesApi, ksStorageClient kssc.Interface, sessionObj *utils.SessionObj, commandResponseChannel *commandResponseChannelData, exporter exporters.Exporter) *ActionHandler {
 	return &ActionHandler{
 		sessionObj:             sessionObj,
 		k8sAPI:                 k8sAPI,
+		ksStorageClient:        ksStorageClient,
 		commandResponseChannel: commandResponseChannel,
 		config:                 config,
 		exporter:               exporter,
@@ -218,7 +220,7 @@ func (mainHandler *MainHandler) HandleSingleRequest(ctx context.Context, session
 	ctx, span := otel.Tracer("").Start(ctx, "mainHandler.HandleSingleRequest")
 	defer span.End()
 
-	actionHandler := NewActionHandler(mainHandler.config, mainHandler.k8sAPI, sessionObj, mainHandler.commandResponseChannel, mainHandler.exporter)
+	actionHandler := NewActionHandler(mainHandler.config, mainHandler.k8sAPI, mainHandler.ksStorageClient, sessionObj, mainHandler.commandResponseChannel, mainHandler.exporter)
 	return actionHandler.runCommand(ctx)
 
 }


### PR DESCRIPTION

**Related issue:** [kubescape/kubescape#1770 — Kubescape CLI control over cluster operations](https://github.com/kubescape/kubescape/issues/1770)
**Design:** [kubescape/designs-and-proposals#5 — Kubescape CLI Control over Cluster Operations](https://github.com/kubescape/designs-and-proposals/pull/5) (merged)
**Contract:** [armosec/armoapi-go#655 — `operatorAction` command contract](https://github.com/armosec/armoapi-go/pull/655) (merged, `v0.0.720`)
**Builds on:**
- [kubescape/operator#383 — Phase 1 remediation (annotate + `Remediator` framework)](https://github.com/kubescape/operator/pull/383) (merged)
- [kubescape/operator#388 — `quarantine` action (deny-all NetworkPolicy)](https://github.com/kubescape/operator/pull/388) (merged)
- [kubescape/helm-charts#855 — opt-in `capabilities.remediation` + gated RBAC](https://github.com/kubescape/helm-charts/pull/855) (merged)

## Overview

This completes the second half of **Phase 2** of the merged design: **findings-driven
targeting**. The operator can already execute `annotate`/`quarantine`/`revert`
against an *explicit* target (`{kind, namespace, name}`). This PR teaches it to
resolve the design's findings-driven **`selector`** — "act on every workload that
fails control `C-0016`" or "…that has a `High`-or-worse finding" — into a concrete
target set, then run the requested action against each.

No re-scan and no new transport: the selector is resolved by reading the scan
results **already stored in the cluster** — the `workloadconfigurationscansummaries`
CRDs in `spdx.softwarecomposition.kubescape.io` — which the operator already has
read access to. Remediation stays a verb on the existing `apis.Command` pipeline.

Until now the handler explicitly rejected the selector:

```go
// before
return fmt.Errorf("operatorAction: findings-driven selector targeting is not supported yet (phase 2); provide an explicit target")
```

With this change, a command carrying a selector instead of a target is executed:

```jsonc
// Command.Args for "annotate every workload failing C-0016 at High or above"
{
  "action":   "annotate",
  "selector": { "control": "C-0016", "minSeverity": "High" },
  "reason":   "C-0016 allowPrivilegeEscalation",
  "dryRun":   true                     // default; only an explicit false writes
}
```

The operator resolves the selector against stored summaries, then applies
`annotate` (dry-run by default) to each matching workload.

## How selection works

A configuration-scan summary matches the selector when:

| Selector | Match rule |
|---|---|
| `control` only | the named control is present **and failing** on that workload |
| `minSeverity` only | the workload has **any failing finding** at or above that severity |
| both | the named control is failing **and** its severity is at or above `minSeverity` |

- **Severity order:** `Critical > High > Medium > Low > Unknown`, so `minSeverity`
  is a simple `>=` floor (`High` matches `Critical` and `High`, excludes `Medium`).
- **Empty selector is rejected, never "match everything".** A selector with
  neither `control` nor `minSeverity` returns an error rather than resolving to
  every workload — the single most important safety guard here.
- **Selector that matches nothing is an explicit error**, not a silent no-op, so
  the caller learns the action had no effect.
- Each resolved workload is mapped back from the summary's
  `kubescape.io/workload-{kind,name,namespace}` labels; summaries missing those
  labels, non-remediable kinds (e.g. `CronJob`), and duplicates (re-scans of the
  same workload) are dropped during resolution so they never reach a remediator.

## What changed

- **`mainhandler/findings.go`** *(new)* — `resolveSelectorTargets`: lists
  `WorkloadConfigurationScanSummaries` cluster-wide, filters by control/severity
  (`summaryMatchesSelector`, `findFailedControl`, `summaryHasFailingSeverityAtLeast`),
  maps matches to `remediators.Target`, and drops excluded namespaces /
  non-remediable kinds / duplicates. Plus the `severityRank` helper.
- **`mainhandler/actionhandler.go`** — `handleOperatorAction` now resolves the
  target set via a new `resolveTargets` (explicit `Target` **or** `Selector`) and
  dispatches each through a new `handleActionOnTarget` (the per-target safety
  rails + action switch, factored out of the old single-target body). A single
  target returns its error verbatim (existing behavior byte-for-byte); a
  multi-target selector runs every target and `errors.Join`s any failures so one
  bad workload doesn't abandon the rest.
- **`mainhandler/handlerequests.go`** — thread the existing `ksStorageClient`
  (`kssc.Interface`) into `ActionHandler` (struct field + `NewActionHandler`
  parameter + its one call site) so the handler can read the scan summaries.
- **Tests** — `findings_test.go` (new) unit-tests the resolver and severity
  ranking; `actionhandler_test.go` replaces the obsolete "not supported yet"
  assertion with end-to-end selector cases (annotates only the failing workload,
  leaves passers untouched, defaults to dry-run, errors when nothing matches).

## Safe-by-default (unchanged)

- **Dry-run is still the default** for selector actions: with `dryRun` unset,
  every matched workload is patched with server-side dry-run
  (`metav1.DryRunAll`), never a real write. Only an explicit `dryRun=false` (the
  CLI's `--confirm`) writes.
- **Namespace rails apply per target.** Excluded/protected namespaces are dropped
  during resolution *and* re-checked before any write, so a selector can never
  reach a protected namespace.
- **RBAC is unchanged.** The read the resolver needs (`list` on
  `workloadconfigurationscansummaries`) is already in the operator's **base**
  ClusterRole — no `helm-charts` change is required, and the mutating verbs stay
  gated behind `capabilities.remediation` from
  [helm-charts#855](https://github.com/kubescape/helm-charts/pull/855). With
  remediation disabled the operator can read findings but still cannot mutate, so
  a selector action fails closed with `Forbidden`.

## Not in scope (follow-ups)

- **CLI flags (`--control` / `--min-severity`).** This is the operator half; the
  paired `kubescape` PR exposes the selector on the `operator remediate`
  subcommand. The operator now understands the selector on the wire regardless of
  which client sends it.
- **Vulnerability-summary targeting.** Selection reads posture
  (`workloadconfigurationscansummaries`), which is what `control` and
  `minSeverity` map to. Driving `minSeverity` off `vulnerabilitymanifestsummaries`
  is a natural extension of the same resolver.
- **`cordon`** — still stubbed; a node action is not workload-findings-driven and
  is left for its own phase.
- **Aggregated multi-target status.** Each resolved workload writes its own
  Kubernetes Event; the single `OperatorCommand` status payload currently reflects
  the last target (a partial failure still surfaces via the joined error). A
  structured per-target status is a reasonable later refinement.

## Testing

- `go build ./...`, `go vet ./mainhandler/...`, and `gofmt` are clean;
  `go mod tidy` is a no-op (all new imports were already direct dependencies).
- `go test -race -count=1 ./mainhandler/ ./mainhandler/remediators/` passes.
- The full `go test ./...` passes for every package except
  `watcher/TestRegistryCommandWatch`, a pre-existing k3s/testcontainers
  integration test that times out booting its container in this environment
  (fails at `k3s.Run(...)` before any operator logic; `watcher` does not import
  `mainhandler`, so it is unaffected by this change).
- New tests cover: control-only, severity-only, and combined selection; the
  empty-selector guard; invalid `minSeverity`; excluded-namespace and
  non-remediable-kind skipping; label-less summaries; de-duplication; and the
  end-to-end handler path (only failing workloads annotated, dry-run default,
  match-nothing error).

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added selector-based actions for targeting workloads based on stored configuration findings.
  - Supports filtering by control and minimum severity.
  - Actions can now run across multiple matching workloads, with individual failures reported together.
  - Automatically skips excluded namespaces, unsupported workload types, and incomplete finding records.
  - Selector actions default to server-side dry-run when no dry-run setting is provided.

- **Bug Fixes**
  - Reports clear errors when selectors are empty or match no workloads.
  - Prevents duplicate actions against the same workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->