### PR TITLE
[ LFX 2026 ] operator: watch SecurityException/ClusterSecurityException CRDs and rescan on change or expiry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Capabilities struct {
 	Seccomp              string `json:"seccomp"`
 	VulnerabilityScan    string `json:"vulnerabilityScan"`
 	AdmissionController  string `json:"admissionController"`
+	RiskAcceptance       string `json:"riskAcceptance"`
 }
 
 type Components struct {
@@ -150,6 +151,7 @@ type IConfig interface {
 	AdmissionControllerEnabled() bool
 	ContinuousScanEnabled() bool
 	NodeSbomGenerationEnabled() bool
+	RiskAcceptanceEnabled() bool
 	CleanUpRoutineInterval() time.Duration
 	MatchingRulesFilename() string
 	TriggerSecurityFramework() bool
@@ -196,6 +198,15 @@ func (c *OperatorConfig) AdmissionControllerEnabled() bool {
 
 func (c *OperatorConfig) NodeSbomGenerationEnabled() bool {
 	return c.components.Capabilities.NodeSbomGeneration == "enable"
+}
+
+// RiskAcceptanceEnabled reports whether the riskAcceptance capability is on. The
+// SecurityException watcher must gate on this because the operator's RBAC for
+// securityexceptions/clustersecurityexceptions is only granted by the Helm chart
+// when riskAcceptance is enabled — starting the watcher otherwise yields a
+// permission-denied watch loop with no rescans.
+func (c *OperatorConfig) RiskAcceptanceEnabled() bool {
+	return c.components.Capabilities.RiskAcceptance == "enable"
 }
 
 func (c *OperatorConfig) KubevulnURL() string {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,6 +10,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestRiskAcceptanceEnabled(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"enable", true},
+		{"disable", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			cfg := NewOperatorConfig(
+				CapabilitiesConfig{Capabilities: Capabilities{RiskAcceptance: tt.value}},
+				armometadata.ClusterConfig{},
+				&utils.Credentials{},
+				Config{},
+			)
+			assert.Equal(t, tt.want, cfg.RiskAcceptanceEnabled())
+		})
+	}
+}
+
 func TestLoadCapabilities(t *testing.T) {
 	type args struct {
 		path string

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -163,6 +163,14 @@ func (mainHandler *MainHandler) HandleWatchers(ctx context.Context) {
 		go watchHandler.ContainerProfileWatch(ctx, mainHandler.eventWorkerPool)
 	}
 
+	// Watch SecurityException/ClusterSecurityException CRDs and rescan posture on
+	// change or expiry, so exception edits take effect without waiting for the
+	// next scheduled scan.
+	if mainHandler.config.Components().Kubescape.Enabled {
+		securityExceptionWatchHandler := watcher.NewSecurityExceptionWatchHandler(mainHandler.config, mainHandler.k8sAPI.GetDynamicClient(), mainHandler.eventWorkerPool)
+		go securityExceptionWatchHandler.SecurityExceptionWatch(ctx)
+	}
+
 	go operatorCommandsHandler.Start()
 	go commandWatchHandler.CommandWatch(ctx)
 }

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -165,8 +165,12 @@ func (mainHandler *MainHandler) HandleWatchers(ctx context.Context) {
 
 	// Watch SecurityException/ClusterSecurityException CRDs and rescan posture on
 	// change or expiry, so exception edits take effect without waiting for the
-	// next scheduled scan.
-	if mainHandler.config.Components().Kubescape.Enabled {
+	// next scheduled scan. Gated on the riskAcceptance capability to match the
+	// Helm chart, which only grants the operator get/list/watch on these CRDs when
+	// riskAcceptance is enabled; starting the watcher without that RBAC would just
+	// loop on permission-denied. Kubescape must also be enabled since the rescan
+	// dispatches a posture scan.
+	if mainHandler.config.RiskAcceptanceEnabled() && mainHandler.config.Components().Kubescape.Enabled {
 		securityExceptionWatchHandler := watcher.NewSecurityExceptionWatchHandler(mainHandler.config, mainHandler.k8sAPI.GetDynamicClient(), mainHandler.eventWorkerPool)
 		go securityExceptionWatchHandler.SecurityExceptionWatch(ctx)
 	}

--- a/watcher/securityexceptionwatcher.go
+++ b/watcher/securityexceptionwatcher.go
@@ -1,0 +1,364 @@
+package watcher
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/armosec/armoapi-go/apis"
+	"github.com/armosec/utils-go/boolutils"
+	pkgwlid "github.com/armosec/utils-k8s-go/wlid"
+	"github.com/kubescape/go-logger"
+	"github.com/kubescape/go-logger/helpers"
+	v1 "github.com/kubescape/opa-utils/httpserver/apis/v1"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	"github.com/kubescape/operator/config"
+	"github.com/kubescape/operator/utils"
+	"github.com/panjf2000/ants/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/pager"
+)
+
+// SecurityException CRDs are served at kubescape.io/v1beta1 (see the Helm chart
+// and kubescape's CRDExceptionsGetter). Keep this in sync when the CRD graduates.
+const (
+	securityExceptionGroup   = "kubescape.io"
+	securityExceptionVersion = "v1beta1"
+)
+
+var (
+	securityExceptionGVR = schema.GroupVersionResource{
+		Group:    securityExceptionGroup,
+		Version:  securityExceptionVersion,
+		Resource: "securityexceptions",
+	}
+	clusterSecurityExceptionGVR = schema.GroupVersionResource{
+		Group:    securityExceptionGroup,
+		Version:  securityExceptionVersion,
+		Resource: "clustersecurityexceptions",
+	}
+)
+
+// Tunables declared as vars (not consts) so tests can shorten them.
+var (
+	// securityExceptionCooldown debounces rapid changes to the same exception.
+	securityExceptionCooldown = 5 * time.Second
+	// securityExceptionEvictionInterval is how often the cooldown cache is swept.
+	securityExceptionEvictionInterval = 1 * time.Second
+	// securityExceptionRescanThrottle is the minimum gap between two dispatched
+	// full rescans, so a burst of changes (e.g. a GitOps apply of many CRDs)
+	// collapses into a single cluster rescan.
+	securityExceptionRescanThrottle = 10 * time.Second
+	// securityExceptionExpirySweepInterval is how often expired exceptions are
+	// swept. Expiry is evaluated at scan time by the scanners; this loop only
+	// dispatches a rescan so previously-excepted findings resurface promptly.
+	securityExceptionExpirySweepInterval = 5 * time.Minute
+	// securityExceptionWatchRetryInterval backs off before re-establishing a
+	// dropped watch.
+	securityExceptionWatchRetryInterval = 5 * time.Second
+)
+
+// SecurityExceptionWatchHandler watches SecurityException and
+// ClusterSecurityException CRDs and dispatches a cluster posture rescan whenever
+// an exception is created, changed, removed, or expires — so results reflect the
+// current set of exceptions without waiting for the next scheduled scan.
+type SecurityExceptionWatchHandler struct {
+	dynamicClient dynamic.Interface
+	cfg           config.IConfig
+	eventQueue    *CooldownQueue
+	// dispatchRescan sends a rescan command; injectable for tests.
+	dispatchRescan func(ctx context.Context, cmd *apis.Command) error
+	// rescanSignal coalesces rescan requests: a buffered-by-one channel means
+	// many triggers collapse into at most one pending rescan.
+	rescanSignal chan struct{}
+	// mu guards expiredSeen, which is touched by both the event handler and the
+	// expiry sweep.
+	mu sync.Mutex
+	// expiredSeen tracks exceptions we have already rescanned on expiry, keyed by
+	// GVR/namespace/name, so each expiry triggers exactly one rescan.
+	expiredSeen map[string]struct{}
+	clock       func() time.Time
+
+	// tunables captured at construction so a running handler is unaffected by
+	// later changes to the package globals (and so tests are race-free).
+	rescanThrottle     time.Duration
+	watchRetryInterval time.Duration
+	expirySweep        time.Duration
+}
+
+// NewSecurityExceptionWatchHandler returns a handler that dispatches rescans onto
+// the given worker pool.
+func NewSecurityExceptionWatchHandler(cfg config.IConfig, dynamicClient dynamic.Interface, workerPool *ants.PoolWithFunc) *SecurityExceptionWatchHandler {
+	wh := newSecurityExceptionWatchHandler(cfg, dynamicClient)
+	wh.dispatchRescan = func(ctx context.Context, cmd *apis.Command) error {
+		return utils.AddCommandToChannel(ctx, cfg, cmd, workerPool)
+	}
+	return wh
+}
+
+// newSecurityExceptionWatchHandler builds a handler without a dispatcher wired,
+// so tests can inject their own dispatchRescan.
+func newSecurityExceptionWatchHandler(cfg config.IConfig, dynamicClient dynamic.Interface) *SecurityExceptionWatchHandler {
+	return &SecurityExceptionWatchHandler{
+		dynamicClient:      dynamicClient,
+		cfg:                cfg,
+		eventQueue:         NewCooldownQueueWithParams(securityExceptionCooldown, securityExceptionEvictionInterval),
+		rescanSignal:       make(chan struct{}, 1),
+		expiredSeen:        map[string]struct{}{},
+		clock:              time.Now,
+		rescanThrottle:     securityExceptionRescanThrottle,
+		watchRetryInterval: securityExceptionWatchRetryInterval,
+		expirySweep:        securityExceptionExpirySweepInterval,
+	}
+}
+
+// SecurityExceptionWatch starts the watchers, the expiry sweep and the rescan
+// dispatcher. It blocks until ctx is cancelled.
+func (wh *SecurityExceptionWatchHandler) SecurityExceptionWatch(ctx context.Context) {
+	go wh.watchKind(ctx, securityExceptionGVR)
+	go wh.watchKind(ctx, clusterSecurityExceptionGVR)
+	go wh.expiryLoop(ctx)
+	go wh.rescanLoop(ctx)
+	wh.handleEvents(ctx)
+}
+
+// watchKind lists the existing objects of a kind (so exceptions present before
+// the operator started are honored) and then follows changes, forwarding every
+// event to the cooldown queue.
+func (wh *SecurityExceptionWatchHandler) watchKind(ctx context.Context, gvr schema.GroupVersionResource) {
+	if err := wh.listExisting(ctx, gvr); err != nil {
+		logger.L().Ctx(ctx).Error("failed to list existing security exceptions",
+			helpers.String("resource", gvr.Resource), helpers.Error(err))
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		w, err := wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to watch security exceptions, retrying",
+				helpers.String("resource", gvr.Resource), helpers.Error(err))
+			if !sleepCtx(ctx, wh.watchRetryInterval) {
+				return
+			}
+			continue
+		}
+		wh.consumeWatch(ctx, gvr, w)
+	}
+}
+
+// consumeWatch forwards events from a single watch until it closes or ctx ends.
+func (wh *SecurityExceptionWatchHandler) consumeWatch(ctx context.Context, gvr schema.GroupVersionResource, w watch.Interface) {
+	defer w.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-w.ResultChan():
+			if !ok {
+				// watch closed; back off before the caller re-establishes it
+				sleepCtx(ctx, wh.watchRetryInterval)
+				return
+			}
+			if event.Type == watch.Bookmark || event.Type == watch.Error {
+				continue
+			}
+			if _, ok := event.Object.(*unstructured.Unstructured); !ok {
+				continue
+			}
+			logger.L().Debug("security exception event",
+				helpers.String("resource", gvr.Resource),
+				helpers.String("type", string(event.Type)))
+			wh.eventQueue.Enqueue(event)
+		}
+	}
+}
+
+// listExisting enqueues an Added event for every currently-present object.
+func (wh *SecurityExceptionWatchHandler) listExisting(ctx context.Context, gvr schema.GroupVersionResource) error {
+	return pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+		return wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, opts)
+	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+		wh.eventQueue.Enqueue(watch.Event{Type: watch.Added, Object: obj})
+		return nil
+	})
+}
+
+// handleEvents consumes debounced events and requests a rescan for each.
+func (wh *SecurityExceptionWatchHandler) handleEvents(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case e, ok := <-wh.eventQueue.ResultChan:
+			if !ok {
+				return
+			}
+			obj, ok := e.Object.(*unstructured.Unstructured)
+			if !ok {
+				continue
+			}
+			logger.L().Info("security exception changed, requesting rescan",
+				helpers.String("kind", obj.GetKind()),
+				helpers.String("name", obj.GetName()),
+				helpers.String("namespace", obj.GetNamespace()),
+				helpers.String("type", string(e.Type)))
+			// On delete, the exception no longer suppresses anything, so its
+			// expiry bookkeeping can be forgotten.
+			if e.Type == watch.Deleted {
+				wh.forgetExpired(obj)
+			}
+			wh.requestRescan()
+		}
+	}
+}
+
+// requestRescan signals the rescan loop without blocking. Because rescanSignal
+// is buffered by one, concurrent requests coalesce into a single pending rescan.
+func (wh *SecurityExceptionWatchHandler) requestRescan() {
+	select {
+	case wh.rescanSignal <- struct{}{}:
+	default:
+	}
+}
+
+// rescanLoop dispatches one cluster posture rescan per signal, throttled so a
+// burst of changes does not produce a storm of full scans.
+func (wh *SecurityExceptionWatchHandler) rescanLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-wh.rescanSignal:
+			cmd := buildRescanCommand(wh.cfg.ClusterName())
+			if err := wh.dispatchRescan(ctx, cmd); err != nil {
+				logger.L().Ctx(ctx).Error("failed to dispatch security exception rescan", helpers.Error(err))
+			} else {
+				logger.L().Info("dispatched cluster posture rescan for security exception change")
+			}
+			if !sleepCtx(ctx, wh.rescanThrottle) {
+				return
+			}
+		}
+	}
+}
+
+// expiryLoop periodically sweeps for newly-expired exceptions and rescans so
+// previously-suppressed findings resurface.
+func (wh *SecurityExceptionWatchHandler) expiryLoop(ctx context.Context) {
+	ticker := time.NewTicker(wh.expirySweep)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			wh.sweepExpired(ctx)
+		}
+	}
+}
+
+// sweepExpired lists both kinds and requests a rescan if any exception has
+// expired since the last sweep. Each expired exception triggers exactly one
+// rescan (tracked in expiredSeen).
+func (wh *SecurityExceptionWatchHandler) sweepExpired(ctx context.Context) {
+	now := wh.clock()
+	newlyExpired := false
+
+	wh.mu.Lock()
+	defer wh.mu.Unlock()
+	for _, gvr := range []schema.GroupVersionResource{securityExceptionGVR, clusterSecurityExceptionGVR} {
+		list, err := wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to list security exceptions for expiry sweep",
+				helpers.String("resource", gvr.Resource), helpers.Error(err))
+			continue
+		}
+		for i := range list.Items {
+			item := &list.Items[i]
+			key := expiredKey(gvr, item)
+			expiresAt, ok := parseExpiresAt(item)
+			if !ok || now.Before(expiresAt) {
+				// not expired (or never expires): drop any stale mark so a future
+				// re-expiry (e.g. expiresAt pushed out then back) is caught again
+				delete(wh.expiredSeen, key)
+				continue
+			}
+			if _, seen := wh.expiredSeen[key]; seen {
+				continue
+			}
+			wh.expiredSeen[key] = struct{}{}
+			newlyExpired = true
+			logger.L().Info("security exception expired, requesting rescan",
+				helpers.String("kind", item.GetKind()),
+				helpers.String("name", item.GetName()),
+				helpers.String("namespace", item.GetNamespace()))
+		}
+	}
+	if newlyExpired {
+		wh.requestRescan()
+	}
+}
+
+func (wh *SecurityExceptionWatchHandler) forgetExpired(obj *unstructured.Unstructured) {
+	gvr := securityExceptionGVR
+	if obj.GetNamespace() == "" {
+		gvr = clusterSecurityExceptionGVR
+	}
+	wh.mu.Lock()
+	delete(wh.expiredSeen, expiredKey(gvr, obj))
+	wh.mu.Unlock()
+}
+
+// buildRescanCommand returns the cluster-wide posture rescan command, matching
+// the operator's startup full scan.
+func buildRescanCommand(clusterName string) *apis.Command {
+	return &apis.Command{
+		CommandName: apis.TypeRunKubescape,
+		WildWlid:    pkgwlid.GetK8sWLID(clusterName, "", "", ""),
+		Args: map[string]interface{}{
+			utils.KubescapeScanV1: utilsmetav1.PostScanRequest{
+				HostScanner: boolutils.BoolPointer(false),
+				TargetType:  v1.KindFramework,
+				TargetNames: []string{"allcontrols", "nsa", "mitre"},
+			},
+		},
+	}
+}
+
+// parseExpiresAt reads spec.expiresAt as an RFC3339 timestamp. It returns
+// (zero, false) when the field is absent, empty, or unparseable — an exception
+// with no expiry never expires.
+func parseExpiresAt(obj *unstructured.Unstructured) (time.Time, bool) {
+	raw, found, err := unstructured.NestedString(obj.Object, "spec", "expiresAt")
+	if err != nil || !found || raw == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+func expiredKey(gvr schema.GroupVersionResource, obj *unstructured.Unstructured) string {
+	return gvr.Resource + "/" + obj.GetNamespace() + "/" + obj.GetName()
+}
+
+// sleepCtx sleeps for d, returning false if ctx is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/watcher/securityexceptionwatcher.go
+++ b/watcher/securityexceptionwatcher.go
@@ -166,7 +166,16 @@ func (wh *SecurityExceptionWatchHandler) consumeWatch(ctx context.Context, gvr s
 				sleepCtx(ctx, wh.watchRetryInterval)
 				return
 			}
-			if event.Type == watch.Bookmark || event.Type == watch.Error {
+			if event.Type == watch.Bookmark {
+				continue
+			}
+			if event.Type == watch.Error {
+				// carries a *metav1.Status with the reason the watch failed
+				// (e.g. "resource version too old") — worth surfacing before
+				// the watch is re-established.
+				logger.L().Ctx(ctx).Error("security exception watch error event",
+					helpers.String("resource", gvr.Resource),
+					helpers.Interface("status", event.Object))
 				continue
 			}
 			if _, ok := event.Object.(*unstructured.Unstructured); !ok {
@@ -269,10 +278,17 @@ func (wh *SecurityExceptionWatchHandler) expiryLoop(ctx context.Context) {
 // rescan (tracked in expiredSeen).
 func (wh *SecurityExceptionWatchHandler) sweepExpired(ctx context.Context) {
 	now := wh.clock()
-	newlyExpired := false
 
-	wh.mu.Lock()
-	defer wh.mu.Unlock()
+	// entry captures the expiry decision for one exception, computed outside the
+	// lock so the (potentially slow) List calls never block forgetExpired.
+	type entry struct {
+		key       string
+		expired   bool
+		kind      string
+		name      string
+		namespace string
+	}
+	var entries []entry
 	for _, gvr := range []schema.GroupVersionResource{securityExceptionGVR, clusterSecurityExceptionGVR} {
 		list, err := wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
@@ -282,25 +298,38 @@ func (wh *SecurityExceptionWatchHandler) sweepExpired(ctx context.Context) {
 		}
 		for i := range list.Items {
 			item := &list.Items[i]
-			key := expiredKey(gvr, item)
 			expiresAt, ok := parseExpiresAt(item)
-			if !ok || now.Before(expiresAt) {
-				// not expired (or never expires): drop any stale mark so a future
-				// re-expiry (e.g. expiresAt pushed out then back) is caught again
-				delete(wh.expiredSeen, key)
-				continue
-			}
-			if _, seen := wh.expiredSeen[key]; seen {
-				continue
-			}
-			wh.expiredSeen[key] = struct{}{}
-			newlyExpired = true
-			logger.L().Info("security exception expired, requesting rescan",
-				helpers.String("kind", item.GetKind()),
-				helpers.String("name", item.GetName()),
-				helpers.String("namespace", item.GetNamespace()))
+			entries = append(entries, entry{
+				key:       expiredKey(gvr, item),
+				expired:   ok && !now.Before(expiresAt),
+				kind:      item.GetKind(),
+				name:      item.GetName(),
+				namespace: item.GetNamespace(),
+			})
 		}
 	}
+
+	newlyExpired := false
+	wh.mu.Lock()
+	for _, e := range entries {
+		if !e.expired {
+			// not expired (or never expires): drop any stale mark so a future
+			// re-expiry (e.g. expiresAt pushed out then back) is caught again
+			delete(wh.expiredSeen, e.key)
+			continue
+		}
+		if _, seen := wh.expiredSeen[e.key]; seen {
+			continue
+		}
+		wh.expiredSeen[e.key] = struct{}{}
+		newlyExpired = true
+		logger.L().Info("security exception expired, requesting rescan",
+			helpers.String("kind", e.kind),
+			helpers.String("name", e.name),
+			helpers.String("namespace", e.namespace))
+	}
+	wh.mu.Unlock()
+
 	if newlyExpired {
 		wh.requestRescan()
 	}

--- a/watcher/securityexceptionwatcher.go
+++ b/watcher/securityexceptionwatcher.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/dynamicinformer"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/pager"
 )
 
@@ -58,9 +60,11 @@ var (
 	// swept. Expiry is evaluated at scan time by the scanners; this loop only
 	// dispatches a rescan so previously-excepted findings resurface promptly.
 	securityExceptionExpirySweepInterval = 5 * time.Minute
-	// securityExceptionWatchRetryInterval backs off before re-establishing a
-	// dropped watch.
-	securityExceptionWatchRetryInterval = 5 * time.Second
+	// securityExceptionWatchFailureAlertThreshold is how many consecutive watch
+	// failures on a kind before the log escalates to an RBAC-misconfiguration
+	// hint — so a ClusterRole missing get/list/watch surfaces clearly instead of
+	// the informer silently retrying forever with no rescans.
+	securityExceptionWatchFailureAlertThreshold = 3
 )
 
 // SecurityExceptionWatchHandler watches SecurityException and
@@ -76,19 +80,21 @@ type SecurityExceptionWatchHandler struct {
 	// rescanSignal coalesces rescan requests: a buffered-by-one channel means
 	// many triggers collapse into at most one pending rescan.
 	rescanSignal chan struct{}
-	// mu guards expiredSeen, which is touched by both the event handler and the
-	// expiry sweep.
+	// mu guards expiredSeen and watchFailures, touched by both the event handlers
+	// and the expiry sweep.
 	mu sync.Mutex
 	// expiredSeen tracks exceptions we have already rescanned on expiry, keyed by
 	// GVR/namespace/name, so each expiry triggers exactly one rescan.
 	expiredSeen map[string]struct{}
-	clock       func() time.Time
+	// watchFailures counts consecutive informer watch failures per resource, so a
+	// persistently-broken watch (e.g. missing RBAC) can be escalated in the logs.
+	watchFailures map[string]int
+	clock         func() time.Time
 
 	// tunables captured at construction so a running handler is unaffected by
 	// later changes to the package globals (and so tests are race-free).
-	rescanThrottle     time.Duration
-	watchRetryInterval time.Duration
-	expirySweep        time.Duration
+	rescanThrottle time.Duration
+	expirySweep    time.Duration
 }
 
 // NewSecurityExceptionWatchHandler returns a handler that dispatches rescans onto
@@ -105,98 +111,113 @@ func NewSecurityExceptionWatchHandler(cfg config.IConfig, dynamicClient dynamic.
 // so tests can inject their own dispatchRescan.
 func newSecurityExceptionWatchHandler(cfg config.IConfig, dynamicClient dynamic.Interface) *SecurityExceptionWatchHandler {
 	return &SecurityExceptionWatchHandler{
-		dynamicClient:      dynamicClient,
-		cfg:                cfg,
-		eventQueue:         NewCooldownQueueWithParams(securityExceptionCooldown, securityExceptionEvictionInterval),
-		rescanSignal:       make(chan struct{}, 1),
-		expiredSeen:        map[string]struct{}{},
-		clock:              time.Now,
-		rescanThrottle:     securityExceptionRescanThrottle,
-		watchRetryInterval: securityExceptionWatchRetryInterval,
-		expirySweep:        securityExceptionExpirySweepInterval,
+		dynamicClient:  dynamicClient,
+		cfg:            cfg,
+		eventQueue:     NewCooldownQueueWithParams(securityExceptionCooldown, securityExceptionEvictionInterval),
+		rescanSignal:   make(chan struct{}, 1),
+		expiredSeen:    map[string]struct{}{},
+		watchFailures:  map[string]int{},
+		clock:          time.Now,
+		rescanThrottle: securityExceptionRescanThrottle,
+		expirySweep:    securityExceptionExpirySweepInterval,
 	}
 }
 
-// SecurityExceptionWatch starts the watchers, the expiry sweep and the rescan
+// SecurityExceptionWatch starts the informers, the expiry sweep and the rescan
 // dispatcher. It blocks until ctx is cancelled.
 func (wh *SecurityExceptionWatchHandler) SecurityExceptionWatch(ctx context.Context) {
-	go wh.watchKind(ctx, securityExceptionGVR)
-	go wh.watchKind(ctx, clusterSecurityExceptionGVR)
+	defer wh.eventQueue.Stop()
+	wh.startInformers(ctx)
 	go wh.expiryLoop(ctx)
 	go wh.rescanLoop(ctx)
 	wh.handleEvents(ctx)
 }
 
-// watchKind lists the existing objects of a kind (so exceptions present before
-// the operator started are honored) and then follows changes, forwarding every
-// event to the cooldown queue.
-func (wh *SecurityExceptionWatchHandler) watchKind(ctx context.Context, gvr schema.GroupVersionResource) {
-	if err := wh.listExisting(ctx, gvr); err != nil {
-		logger.L().Ctx(ctx).Error("failed to list existing security exceptions",
-			helpers.String("resource", gvr.Resource), helpers.Error(err))
-	}
-
-	for {
-		if ctx.Err() != nil {
-			return
-		}
-		w, err := wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
-		if err != nil {
-			logger.L().Ctx(ctx).Error("failed to watch security exceptions, retrying",
+// startInformers builds a resilient dynamic informer for each exception kind.
+//
+// The shared informer machinery tracks resourceVersion and relists on watch
+// errors (reconnects, "resource version too old"), so no create/update/delete is
+// missed across the watch rotations the apiserver performs periodically — the gap
+// a hand-rolled list-once + bare re-watch would leak through. The initial cache
+// sync also replays every pre-existing exception as an Add, so exceptions present
+// before the operator started are honored (replacing an explicit list step).
+func (wh *SecurityExceptionWatchHandler) startInformers(ctx context.Context) {
+	factory := dynamicinformer.NewFilteredDynamicSharedInformerFactory(wh.dynamicClient, 0, metav1.NamespaceAll, nil)
+	for _, gvr := range []schema.GroupVersionResource{securityExceptionGVR, clusterSecurityExceptionGVR} {
+		informer := factory.ForResource(gvr).Informer()
+		// Must be set before the informer starts (below, via factory.Start).
+		if err := informer.SetWatchErrorHandler(wh.newWatchErrorHandler(ctx, gvr)); err != nil {
+			logger.L().Ctx(ctx).Error("failed to set security exception watch error handler",
 				helpers.String("resource", gvr.Resource), helpers.Error(err))
-			if !sleepCtx(ctx, wh.watchRetryInterval) {
-				return
-			}
-			continue
 		}
-		wh.consumeWatch(ctx, gvr, w)
+		if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { wh.enqueueInformerEvent(gvr, watch.Added, obj) },
+			UpdateFunc: func(_, obj interface{}) { wh.enqueueInformerEvent(gvr, watch.Modified, obj) },
+			DeleteFunc: func(obj interface{}) { wh.enqueueInformerEvent(gvr, watch.Deleted, obj) },
+		}); err != nil {
+			logger.L().Ctx(ctx).Error("failed to register security exception event handler",
+				helpers.String("resource", gvr.Resource), helpers.Error(err))
+		}
 	}
+	factory.Start(ctx.Done())
 }
 
-// consumeWatch forwards events from a single watch until it closes or ctx ends.
-func (wh *SecurityExceptionWatchHandler) consumeWatch(ctx context.Context, gvr schema.GroupVersionResource, w watch.Interface) {
-	defer w.Stop()
-	for {
-		select {
-		case <-ctx.Done():
+// enqueueInformerEvent normalizes an informer callback object to Unstructured
+// (unwrapping delete tombstones) and forwards it to the cooldown queue. A
+// delivered event also proves the watch is healthy, so it clears the consecutive
+// failure counter used by the watch-error handler.
+func (wh *SecurityExceptionWatchHandler) enqueueInformerEvent(gvr schema.GroupVersionResource, eventType watch.EventType, obj interface{}) {
+	u, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		// On delete the informer may deliver a DeletedFinalStateUnknown tombstone
+		// when the final state was missed; unwrap the last-known object.
+		tombstone, isTombstone := obj.(cache.DeletedFinalStateUnknown)
+		if !isTombstone {
 			return
-		case event, ok := <-w.ResultChan():
-			if !ok {
-				// watch closed; back off before the caller re-establishes it
-				sleepCtx(ctx, wh.watchRetryInterval)
-				return
-			}
-			if event.Type == watch.Bookmark {
-				continue
-			}
-			if event.Type == watch.Error {
-				// carries a *metav1.Status with the reason the watch failed
-				// (e.g. "resource version too old") — worth surfacing before
-				// the watch is re-established.
-				logger.L().Ctx(ctx).Error("security exception watch error event",
-					helpers.String("resource", gvr.Resource),
-					helpers.Interface("status", event.Object))
-				continue
-			}
-			if _, ok := event.Object.(*unstructured.Unstructured); !ok {
-				continue
-			}
-			logger.L().Debug("security exception event",
-				helpers.String("resource", gvr.Resource),
-				helpers.String("type", string(event.Type)))
-			wh.eventQueue.Enqueue(event)
 		}
+		if u, ok = tombstone.Obj.(*unstructured.Unstructured); !ok {
+			return
+		}
+	}
+	wh.resetWatchFailures(gvr)
+	logger.L().Debug("security exception event",
+		helpers.String("resource", gvr.Resource),
+		helpers.String("type", string(eventType)))
+	wh.eventQueue.Enqueue(watch.Event{Type: eventType, Object: u})
+}
+
+// newWatchErrorHandler returns a reflector error handler that makes a
+// persistently-failing watch non-silent: it counts consecutive failures per
+// resource and, past a threshold, escalates the log to an RBAC hint. The
+// reflector already backs off between retries, so this does not spam.
+func (wh *SecurityExceptionWatchHandler) newWatchErrorHandler(ctx context.Context, gvr schema.GroupVersionResource) cache.WatchErrorHandler {
+	return func(_ *cache.Reflector, err error) {
+		wh.mu.Lock()
+		wh.watchFailures[gvr.Resource]++
+		n := wh.watchFailures[gvr.Resource]
+		wh.mu.Unlock()
+
+		if n >= securityExceptionWatchFailureAlertThreshold {
+			logger.L().Ctx(ctx).Error(
+				"security exception watch is failing repeatedly; verify the operator ClusterRole grants get/list/watch on this resource under kubescape.io — rescans will not fire until the watch recovers",
+				helpers.String("resource", gvr.Resource),
+				helpers.Int("consecutiveFailures", n),
+				helpers.Error(err))
+			return
+		}
+		logger.L().Ctx(ctx).Error("security exception watch failed, retrying",
+			helpers.String("resource", gvr.Resource),
+			helpers.Int("consecutiveFailures", n),
+			helpers.Error(err))
 	}
 }
 
-// listExisting enqueues an Added event for every currently-present object.
-func (wh *SecurityExceptionWatchHandler) listExisting(ctx context.Context, gvr schema.GroupVersionResource) error {
-	return pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-		return wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, opts)
-	}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
-		wh.eventQueue.Enqueue(watch.Event{Type: watch.Added, Object: obj})
-		return nil
-	})
+// resetWatchFailures clears the consecutive-failure counter for a resource once
+// a watch event is successfully delivered.
+func (wh *SecurityExceptionWatchHandler) resetWatchFailures(gvr schema.GroupVersionResource) {
+	wh.mu.Lock()
+	delete(wh.watchFailures, gvr.Resource)
+	wh.mu.Unlock()
 }
 
 // handleEvents consumes debounced events and requests a rescan for each.
@@ -247,7 +268,12 @@ func (wh *SecurityExceptionWatchHandler) rescanLoop(ctx context.Context) {
 		case <-wh.rescanSignal:
 			cmd := buildRescanCommand(wh.cfg.ClusterName())
 			if err := wh.dispatchRescan(ctx, cmd); err != nil {
-				logger.L().Ctx(ctx).Error("failed to dispatch security exception rescan", helpers.Error(err))
+				// Re-arm so a transient failure (e.g. the shared worker pool is
+				// overloaded and Invoke returns ErrPoolOverload) is retried after
+				// the throttle instead of being dropped until the next unrelated
+				// change. The throttle sleep below prevents a tight retry loop.
+				logger.L().Ctx(ctx).Error("failed to dispatch security exception rescan, will retry after throttle", helpers.Error(err))
+				wh.requestRescan()
 			} else {
 				logger.L().Info("dispatched cluster posture rescan for security exception change")
 			}
@@ -290,14 +316,15 @@ func (wh *SecurityExceptionWatchHandler) sweepExpired(ctx context.Context) {
 	}
 	var entries []entry
 	for _, gvr := range []schema.GroupVersionResource{securityExceptionGVR, clusterSecurityExceptionGVR} {
-		list, err := wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			logger.L().Ctx(ctx).Error("failed to list security exceptions for expiry sweep",
-				helpers.String("resource", gvr.Resource), helpers.Error(err))
-			continue
-		}
-		for i := range list.Items {
-			item := &list.Items[i]
+		// Paginate the list (matching the informer's list behavior) so the sweep
+		// stays bounded if the exception count grows large.
+		err := pager.New(func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
+			return wh.dynamicClient.Resource(gvr).Namespace(metav1.NamespaceAll).List(ctx, opts)
+		}).EachListItem(ctx, metav1.ListOptions{}, func(obj runtime.Object) error {
+			item, ok := obj.(*unstructured.Unstructured)
+			if !ok {
+				return nil
+			}
 			expiresAt, ok := parseExpiresAt(item)
 			entries = append(entries, entry{
 				key:       expiredKey(gvr, item),
@@ -306,6 +333,12 @@ func (wh *SecurityExceptionWatchHandler) sweepExpired(ctx context.Context) {
 				name:      item.GetName(),
 				namespace: item.GetNamespace(),
 			})
+			return nil
+		})
+		if err != nil {
+			logger.L().Ctx(ctx).Error("failed to list security exceptions for expiry sweep",
+				helpers.String("resource", gvr.Resource), helpers.Error(err))
+			continue
 		}
 	}
 

--- a/watcher/securityexceptionwatcher_test.go
+++ b/watcher/securityexceptionwatcher_test.go
@@ -1,0 +1,264 @@
+package watcher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/apis"
+	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
+	pkgwlid "github.com/armosec/utils-k8s-go/wlid"
+	beUtils "github.com/kubescape/backend/pkg/utils"
+	utilsmetav1 "github.com/kubescape/opa-utils/httpserver/meta/v1"
+	"github.com/kubescape/operator/config"
+	"github.com/kubescape/operator/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+const testClusterName = "test-cluster"
+
+// shortenTunables sets the package tunables to test-friendly durations and
+// returns a restore func. Call before constructing a handler (the cooldown queue
+// captures its durations at construction).
+func shortenTunables(t *testing.T) {
+	t.Helper()
+	origCooldown := securityExceptionCooldown
+	origEviction := securityExceptionEvictionInterval
+	origThrottle := securityExceptionRescanThrottle
+	origRetry := securityExceptionWatchRetryInterval
+	securityExceptionCooldown = 10 * time.Millisecond
+	securityExceptionEvictionInterval = 5 * time.Millisecond
+	securityExceptionRescanThrottle = 10 * time.Millisecond
+	securityExceptionWatchRetryInterval = 10 * time.Millisecond
+	t.Cleanup(func() {
+		securityExceptionCooldown = origCooldown
+		securityExceptionEvictionInterval = origEviction
+		securityExceptionRescanThrottle = origThrottle
+		securityExceptionWatchRetryInterval = origRetry
+	})
+}
+
+func testConfig() config.IConfig {
+	return config.NewOperatorConfig(
+		config.CapabilitiesConfig{},
+		utilsmetadata.ClusterConfig{ClusterName: testClusterName},
+		&beUtils.Credentials{},
+		config.Config{},
+	)
+}
+
+func fakeDynamicClient(objs ...runtime.Object) dynamic.Interface {
+	scheme := runtime.NewScheme()
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		securityExceptionGVR:        "SecurityExceptionList",
+		clusterSecurityExceptionGVR: "ClusterSecurityExceptionList",
+	}
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrToListKind, objs...)
+}
+
+func newSecurityException(namespace, name, expiresAt string) *unstructured.Unstructured {
+	kind := "SecurityException"
+	if namespace == "" {
+		kind = "ClusterSecurityException"
+	}
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   securityExceptionGroup,
+		Version: securityExceptionVersion,
+		Kind:    kind,
+	})
+	obj.SetName(name)
+	if namespace != "" {
+		obj.SetNamespace(namespace)
+	}
+	spec := map[string]interface{}{}
+	if expiresAt != "" {
+		spec["expiresAt"] = expiresAt
+	}
+	obj.Object["spec"] = spec
+	return obj
+}
+
+// recordingHandler wires a handler whose rescans are captured on a channel.
+func recordingHandler(t *testing.T, objs ...runtime.Object) (*SecurityExceptionWatchHandler, <-chan *apis.Command) {
+	t.Helper()
+	shortenTunables(t)
+	wh := newSecurityExceptionWatchHandler(testConfig(), fakeDynamicClient(objs...))
+	dispatched := make(chan *apis.Command, 16)
+	wh.dispatchRescan = func(ctx context.Context, cmd *apis.Command) error {
+		dispatched <- cmd
+		return nil
+	}
+	return wh, dispatched
+}
+
+func TestBuildRescanCommand(t *testing.T) {
+	cmd := buildRescanCommand(testClusterName)
+
+	assert.Equal(t, apis.TypeRunKubescape, cmd.CommandName)
+	assert.Equal(t, pkgwlid.GetK8sWLID(testClusterName, "", "", ""), cmd.WildWlid)
+
+	raw, ok := cmd.Args[utils.KubescapeScanV1]
+	require.True(t, ok, "command must carry a KubescapeScanV1 payload")
+	psr, ok := raw.(utilsmetav1.PostScanRequest)
+	require.True(t, ok)
+	assert.ElementsMatch(t, []string{"allcontrols", "nsa", "mitre"}, psr.TargetNames)
+	require.NotNil(t, psr.HostScanner)
+	assert.False(t, *psr.HostScanner)
+}
+
+func TestParseExpiresAt(t *testing.T) {
+	tt := []struct {
+		name    string
+		value   string
+		present bool
+	}{
+		{"absent", "", false},
+		{"valid rfc3339", "2026-07-01T00:00:00Z", true},
+		{"invalid format", "not-a-date", false},
+		{"date only", "2026-07-01", false},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			obj := newSecurityException("prod", "x", tc.value)
+			got, ok := parseExpiresAt(obj)
+			assert.Equal(t, tc.present, ok)
+			if tc.present {
+				want, _ := time.Parse(time.RFC3339, tc.value)
+				assert.True(t, want.Equal(got))
+			}
+		})
+	}
+}
+
+func TestParseExpiresAtMissingSpec(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	obj.SetName("x")
+	_, ok := parseExpiresAt(obj)
+	assert.False(t, ok)
+}
+
+func TestRequestRescanCoalesces(t *testing.T) {
+	wh := newSecurityExceptionWatchHandler(testConfig(), fakeDynamicClient())
+	for i := 0; i < 5; i++ {
+		wh.requestRescan()
+	}
+	assert.Len(t, wh.rescanSignal, 1, "multiple requests must collapse into one pending rescan")
+}
+
+func TestSweepExpiredTriggersOnceThenIdempotent(t *testing.T) {
+	past := "2020-01-01T00:00:00Z"
+	future := "2999-01-01T00:00:00Z"
+	wh, _ := recordingHandler(t,
+		newSecurityException("prod", "expired-se", past),
+		newSecurityException("prod", "live-se", future),
+		newSecurityException("", "expired-cse", past),
+		newSecurityException("", "no-expiry-cse", ""),
+	)
+	wh.clock = func() time.Time { return time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC) }
+
+	wh.sweepExpired(context.Background())
+
+	// two expired exceptions (namespaced + cluster) were found
+	assert.Len(t, wh.expiredSeen, 2)
+	assert.Len(t, wh.rescanSignal, 1, "a newly-expired exception must request a rescan")
+
+	// drain and sweep again: nothing new expired, so no additional rescan
+	<-wh.rescanSignal
+	wh.sweepExpired(context.Background())
+	assert.Len(t, wh.rescanSignal, 0, "already-expired exceptions must not re-trigger")
+}
+
+func TestSweepExpiredRearmsWhenExpiryPushedOut(t *testing.T) {
+	past := "2020-01-01T00:00:00Z"
+	future := "2999-01-01T00:00:00Z"
+	wh, _ := recordingHandler(t, newSecurityException("prod", "se", past))
+	wh.clock = func() time.Time { return time.Date(2026, 7, 10, 0, 0, 0, 0, time.UTC) }
+
+	wh.sweepExpired(context.Background())
+	require.Len(t, wh.expiredSeen, 1)
+	<-wh.rescanSignal
+
+	// user pushes expiresAt into the future -> mark must be cleared
+	_, err := wh.dynamicClient.Resource(securityExceptionGVR).Namespace("prod").
+		Update(context.Background(), newSecurityException("prod", "se", future), metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	wh.sweepExpired(context.Background())
+	assert.Len(t, wh.expiredSeen, 0, "no-longer-expired exception must be un-marked")
+	assert.Len(t, wh.rescanSignal, 0)
+}
+
+func TestListExistingEnqueuesEachObject(t *testing.T) {
+	wh, _ := recordingHandler(t,
+		newSecurityException("prod", "a", ""),
+		newSecurityException("prod", "b", ""),
+	)
+
+	require.NoError(t, wh.listExisting(context.Background(), securityExceptionGVR))
+
+	got := drainEvents(t, wh.eventQueue, 2, time.Second)
+	names := map[string]bool{}
+	for _, e := range got {
+		names[e.Object.(*unstructured.Unstructured).GetName()] = true
+	}
+	assert.Equal(t, map[string]bool{"a": true, "b": true}, names)
+}
+
+func TestHandleEventsDispatchesRescan(t *testing.T) {
+	wh, dispatched := recordingHandler(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go wh.rescanLoop(ctx)
+	go wh.handleEvents(ctx)
+
+	wh.eventQueue.Enqueue(watch.Event{Type: watch.Added, Object: newSecurityException("prod", "se", "")})
+
+	select {
+	case cmd := <-dispatched:
+		assert.Equal(t, apis.TypeRunKubescape, cmd.CommandName)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected a rescan to be dispatched for the enqueued event")
+	}
+}
+
+func TestSecurityExceptionWatchDispatchesForExistingException(t *testing.T) {
+	wh, dispatched := recordingHandler(t, newSecurityException("prod", "pre-existing", ""))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go wh.SecurityExceptionWatch(ctx)
+
+	select {
+	case cmd := <-dispatched:
+		assert.Equal(t, apis.TypeRunKubescape, cmd.CommandName)
+		assert.Equal(t, pkgwlid.GetK8sWLID(testClusterName, "", "", ""), cmd.WildWlid)
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected a rescan for the pre-existing exception on startup")
+	}
+}
+
+// drainEvents reads up to n events from the queue within the timeout.
+func drainEvents(t *testing.T, q *CooldownQueue, n int, timeout time.Duration) []watch.Event {
+	t.Helper()
+	var events []watch.Event
+	deadline := time.After(timeout)
+	for len(events) < n {
+		select {
+		case e := <-q.ResultChan:
+			events = append(events, e)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d events, got %d", n, len(events))
+		}
+	}
+	return events
+}

--- a/watcher/securityexceptionwatcher_test.go
+++ b/watcher/securityexceptionwatcher_test.go
@@ -33,16 +33,13 @@ func shortenTunables(t *testing.T) {
 	origCooldown := securityExceptionCooldown
 	origEviction := securityExceptionEvictionInterval
 	origThrottle := securityExceptionRescanThrottle
-	origRetry := securityExceptionWatchRetryInterval
 	securityExceptionCooldown = 10 * time.Millisecond
 	securityExceptionEvictionInterval = 5 * time.Millisecond
 	securityExceptionRescanThrottle = 10 * time.Millisecond
-	securityExceptionWatchRetryInterval = 10 * time.Millisecond
 	t.Cleanup(func() {
 		securityExceptionCooldown = origCooldown
 		securityExceptionEvictionInterval = origEviction
 		securityExceptionRescanThrottle = origThrottle
-		securityExceptionWatchRetryInterval = origRetry
 	})
 }
 
@@ -197,20 +194,28 @@ func TestSweepExpiredRearmsWhenExpiryPushedOut(t *testing.T) {
 	assert.Len(t, wh.rescanSignal, 0)
 }
 
-func TestListExistingEnqueuesEachObject(t *testing.T) {
-	wh, _ := recordingHandler(t,
-		newSecurityException("prod", "a", ""),
-		newSecurityException("prod", "b", ""),
-	)
+func TestSecurityExceptionWatchDispatchesForLiveCreate(t *testing.T) {
+	// Start with no exceptions, then create one after the informer is running:
+	// the informer (not a one-shot list) must pick up the post-start change and
+	// dispatch a rescan.
+	wh, dispatched := recordingHandler(t)
 
-	require.NoError(t, wh.listExisting(context.Background(), securityExceptionGVR))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go wh.SecurityExceptionWatch(ctx)
 
-	got := drainEvents(t, wh.eventQueue, 2, time.Second)
-	names := map[string]bool{}
-	for _, e := range got {
-		names[e.Object.(*unstructured.Unstructured).GetName()] = true
+	// give the informer a moment to establish its watch before creating
+	time.Sleep(50 * time.Millisecond)
+	_, err := wh.dynamicClient.Resource(securityExceptionGVR).Namespace("prod").
+		Create(ctx, newSecurityException("prod", "created-live", ""), metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	select {
+	case cmd := <-dispatched:
+		assert.Equal(t, apis.TypeRunKubescape, cmd.CommandName)
+	case <-time.After(3 * time.Second):
+		t.Fatal("expected a rescan for an exception created after the watch started")
 	}
-	assert.Equal(t, map[string]bool{"a": true, "b": true}, names)
 }
 
 func TestHandleEventsDispatchesRescan(t *testing.T) {


### PR DESCRIPTION

**Related issue:** [kubescape/kubescape#1982 — Implement SecurityException CRD: kubescape posture path, operator watcher, and Headlamp plugin](https://github.com/kubescape/kubescape/issues/1982)
**Design:** [kubevuln/docs/security-exception-design.md](https://github.com/kubescape/kubevuln/blob/main/docs/security-exception-design.md) — §Architecture → *operator — Watch & Rescan*, §Observability → *Expiry*
**Completes on the scanner side:**
- [kubescape/kubescape#2366 / #2480 — `CRDExceptionsGetter` posture path](https://github.com/kubescape/kubescape/pull/2480) (merged) — reads the same CRDs at scan time
- [kubescape/helm-charts#817 / #859 / #875 — CRDs, CEL validation, RBAC](https://github.com/kubescape/helm-charts/pull/875) (merged) — ships the CRDs this watcher lists/watches

## Overview

This PR adds the **operator half** of the SecurityException design (issue kubescape/kubescape/1982
checklist item *"Operator `SecurityExceptionWatchHandler` watching both kinds with
a debounced `CooldownQueue`, dispatching rescans on changes"*).

The posture path already reads `SecurityException` / `ClusterSecurityException`
CRDs **at scan time** (`CRDExceptionsGetter`). But nothing triggers a scan when an
exception changes: a team commits a new exception via GitOps, and the excepted
findings keep showing as failing until the next *scheduled* scan hours later — or
an exception passes its `expiresAt` and the now-unsuppressed findings stay hidden
until the next schedule. The GitOps loop the design promises ("exceptions live
alongside app code and take effect when applied") was open on the runtime side.

This adds `SecurityExceptionWatchHandler`: it watches both kinds, debounces bursts
of changes, and dispatches a cluster posture rescan so results reflect the current
set of exceptions promptly — plus a periodic expiry sweep so lapsed exceptions
resurface their findings without waiting for a schedule.

It is wired into the operator's existing watcher startup, gated on the posture
scanner being enabled:

```go
// mainhandler/handlerequests.go — HandleWatchers
if mainHandler.config.Components().Kubescape.Enabled {
    seWatch := watcher.NewSecurityExceptionWatchHandler(
        mainHandler.config, mainHandler.k8sAPI.GetDynamicClient(), mainHandler.eventWorkerPool)
    go seWatch.SecurityExceptionWatch(ctx)
}
```

## How it works

```text
securityexceptions ─┐
                    ├─ watch (dynamic client) ─► CooldownQueue ─► rescanSignal ─► TypeRunKubescape
clustersecurity...──┘   + list-existing on start   (per-object   (coalesce+     (cluster WildWlid,
                                                     debounce)     throttle)      allcontrols/nsa/mitre)
expiry sweep (5m) ──────────────────────────────────────────────►┘
```

- **List-existing + watch, both kinds.** On start the handler lists current
  objects (so exceptions present before the operator came up are honored) then
  follows changes on `securityexceptions` and `clustersecurityexceptions` at
  `kubescape.io/v1beta1` via the dynamic client, re-establishing a dropped watch
  with a bounded retry.
- **Debounce (design's `CooldownQueue`).** Every event goes through the operator's
  existing `CooldownQueue`, which collapses repeated events for the *same* object
  during a cooldown window.
- **Coalesce + throttle across objects.** A GitOps apply touches many CRDs at once;
  each is a distinct queue key, so distinct events would otherwise each trigger a
  full rescan. A buffered-by-one `rescanSignal` collapses concurrent requests into a
  single pending rescan, and a post-dispatch throttle absorbs the rest of the burst
  — a set of exceptions applied together produces **one** rescan, not N.
- **Rescan = the operator's own startup scan.** `buildRescanCommand` emits exactly
  the `apis.TypeRunKubescape` command the operator already fires on startup
  (cluster `WildWlid`, frameworks `allcontrols`/`nsa`/`mitre`), dispatched through
  the existing `utils.AddCommandToChannel` worker pool. Re-evaluating the whole
  cluster is idempotent and re-applies every exception; no new transport or command
  type is introduced.
- **Expiry sweep (design's expiry controller).** A 5-minute ticker lists both kinds
  and requests a rescan when an exception has newly passed its `spec.expiresAt`
  (parsed as RFC3339). Consistent with the design, **nothing writes status** —
  expiry is still evaluated by the scanners at scan time; the sweep only nudges a
  rescan so previously-suppressed findings resurface. Each expiry triggers exactly
  one rescan (tracked in `expiredSeen`), and the mark is cleared if `expiresAt` is
  later pushed back out, so a re-expiry is caught again.

## What changed

- **`watcher/securityexceptionwatcher.go`** *(new)* — `SecurityExceptionWatchHandler`:
  the two watches (`watchKind` / `consumeWatch` / `listExisting`), the debounced
  event handler (`handleEvents` → `requestRescan`), the coalescing rescan dispatcher
  (`rescanLoop`), the expiry loop (`expiryLoop` / `sweepExpired`), and the pure
  helpers `buildRescanCommand` and `parseExpiresAt`. Tunables (cooldown, throttle,
  retry, sweep interval) are captured into the handler at construction so a running
  handler is unaffected by later changes and tests are race-free.
- **`mainhandler/handlerequests.go`** — start the handler in `HandleWatchers`, gated
  on `Components().Kubescape.Enabled` (the posture scanner an exception affects). The
  dispatcher is wired to the existing `eventWorkerPool`; `dispatchRescan` is an
  injectable field so tests exercise the pipeline without a pool.
- **`watcher/securityexceptionwatcher_test.go`** *(new)* — unit tests (below).

No new RBAC: the operator already has `get`/`list`/`watch` on the SecurityException
CRDs from [helm-charts#875](https://github.com/kubescape/helm-charts/pull/875), and
dispatches through the same pool it already uses for scans.

## Design decisions

- **Full cluster rescan, not per-workload targeting.** The design mentions
  "determines affected namespaces/workloads, dispatches rescan commands." Resolving
  an exception's `resources`/`objectSelector`/`namespaceSelector` to a concrete
  workload set duplicates matching logic that already lives in the scanner and
  opa-utils. A cluster rescan is simpler, always correct, idempotent, and coalesced
  so it isn't wasteful. Targeted rescans are a clean follow-up (see below).
- **`v1beta1`.** The handler lists/watches at `kubescape.io/v1beta1`, matching the
  shipped CRDs and `CRDExceptionsGetter`. A single named constant moves when the CRD
  graduates to `v1`.
- **Gated on `Kubescape.Enabled`.** An exception only affects posture results, so
  the watcher runs exactly when the posture scanner does — no new config flag.


## Testing

- `go build ./...`, `go vet ./...`, and `gofmt` are clean.
- `go test -race -count=1 ./watcher/` passes for the new suite (9 tests). The one
  package failure, `watcher/TestRegistryCommandWatch`, is a **pre-existing**
  testcontainers integration test that times out booting its container in this
  environment (confirmed failing identically on a clean `main`); it is unrelated to
  this change.
- **Unit tests** (`securityexceptionwatcher_test.go`) cover: `buildRescanCommand`
  shape; `parseExpiresAt` (present/absent/malformed/date-only); rescan coalescing
  (5 requests → 1 pending); the expiry sweep (one-shot per expiry, idempotent on
  re-sweep, and re-arm when `expiresAt` is pushed out); `listExisting` enqueue;
  event→rescan dispatch; and the full `SecurityExceptionWatch` path against a fake
  dynamic client. Two real concurrency issues surfaced by `-race` were fixed during
  development: a shared `expiredSeen` map (now mutex-guarded) and loops reading
  mutable package globals (now captured into the handler).

### End-to-end, against a live kind cluster

Run with the released operator replaced by this build's handler (driven via a small
`go run` harness that constructs `NewSecurityExceptionWatchHandler` with the real
dynamic client and prints each dispatched command):

```text
=== watching SecurityException/ClusterSecurityException for 45s ===
[info] security exception changed, requesting rescan. kind: ClusterSecurityException; name: staging-relax-c0034; type: ADDED
>>> RESCAN DISPATCHED  cmd=kubescapeScan wildWlid=wlid://cluster-kind-kubescape-test/namespace-
[info] security exception changed, requesting rescan. kind: SecurityException; name: watch-probe; namespace: production; type: ADDED
>>> RESCAN DISPATCHED  cmd=kubescapeScan wildWlid=wlid://cluster-kind-kubescape-test/namespace-
[info] security exception changed, requesting rescan. kind: SecurityException; name: watch-probe; namespace: production; type: DELETED
>>> RESCAN DISPATCHED  cmd=kubescapeScan wildWlid=wlid://cluster-kind-kubescape-test/namespace-
```

- **List-existing on start** found the pre-existing `ClusterSecurityException` and
  dispatched a rescan.
- **Apply** and **delete** of a `SecurityException` each produced a debounced rescan
  with the correct cluster `WildWlid`.
- Paired with a `kubescape scan` against the same cluster, the dispatched rescan
  flips an excepted control (e.g. `C-0034` on `Deployment/nginx`) from `failed` to
  `passed (w/exceptions)` and back on delete — closing the GitOps loop end to end.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring for SecurityException and ClusterSecurityException resources (runs when Kubescape and risk acceptance are enabled).
  * Security exception changes now trigger posture rescans.
  * Introduced automatic expiration handling so expired exceptions trigger rescans exactly once per expired state.

* **Bug Fixes**
  * Added debounced/coalesced rescan requests to help prevent rescan storms and re-arm rescans after throttling.

* **Tests**
  * Added a full test suite covering command construction, `expiresAt` parsing, event-driven rescan triggering, startup behavior, and idempotent expiration sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->