### PR TITLE
feat: honor install-time defaultFrameworks for posture scans

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -165,6 +165,9 @@ type IConfig interface {
 	SkipProfilesWithoutInstances() bool
 	RulesUpdateEnabled() bool
 	NodeAgentAutoscalerConfig() NodeAgentAutoscalerConfig
+	// DefaultFrameworks returns install-time posture frameworks from clusterData.
+	// Empty means callers should keep their legacy fallback (e.g. "all" or the native trio).
+	DefaultFrameworks() []string
 }
 
 // OperatorConfig implements IConfig
@@ -255,6 +258,15 @@ func (c *OperatorConfig) AccessKey() string {
 
 func (c *OperatorConfig) ClusterName() string {
 	return c.clusterConfig.ClusterName
+}
+
+func (c *OperatorConfig) DefaultFrameworks() []string {
+	if len(c.clusterConfig.DefaultFrameworks) == 0 {
+		return nil
+	}
+	out := make([]string, len(c.clusterConfig.DefaultFrameworks))
+	copy(out, c.clusterConfig.DefaultFrameworks)
+	return out
 }
 
 func (c *OperatorConfig) SkipNamespace(ns string) bool {

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strings"
 	"time"
 
 	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
@@ -261,11 +262,15 @@ func (c *OperatorConfig) ClusterName() string {
 }
 
 func (c *OperatorConfig) DefaultFrameworks() []string {
-	if len(c.clusterConfig.DefaultFrameworks) == 0 {
+	out := make([]string, 0, len(c.clusterConfig.DefaultFrameworks))
+	for _, f := range c.clusterConfig.DefaultFrameworks {
+		if f = strings.TrimSpace(f); f != "" {
+			out = append(out, f)
+		}
+	}
+	if len(out) == 0 {
 		return nil
 	}
-	out := make([]string, len(c.clusterConfig.DefaultFrameworks))
-	copy(out, c.clusterConfig.DefaultFrameworks)
 	return out
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/utils-k8s-go/armometadata"
 	"github.com/kubescape/backend/pkg/utils"
 	"github.com/kubescape/operator/admission/rulesupdate"
@@ -245,3 +246,33 @@ func TestValidateConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultFrameworks(t *testing.T) {
+	tests := []struct {
+		name        string
+		frameworks  []string
+		want        []string
+	}{
+		{"empty", nil, nil},
+		{"empty slice", []string{}, nil},
+		{"custom", []string{"cis-aks-t1.2.0", "nsa"}, []string{"cis-aks-t1.2.0", "nsa"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewOperatorConfig(
+				CapabilitiesConfig{},
+				armometadata.ClusterConfig{InstallationData: armotypes.InstallationData{DefaultFrameworks: tt.frameworks}},
+				&utils.Credentials{},
+				Config{},
+			)
+			got := cfg.DefaultFrameworks()
+			assert.Equal(t, tt.want, got)
+			// returned slice must be a copy
+			if len(got) > 0 {
+				got[0] = "mutated"
+				assert.Equal(t, tt.want, cfg.DefaultFrameworks())
+			}
+		})
+	}
+}
+

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -249,13 +249,15 @@ func TestValidateConfig(t *testing.T) {
 
 func TestDefaultFrameworks(t *testing.T) {
 	tests := []struct {
-		name        string
-		frameworks  []string
-		want        []string
+		name       string
+		frameworks []string
+		want       []string
 	}{
 		{"empty", nil, nil},
 		{"empty slice", []string{}, nil},
+		{"blanks only", []string{"", "  "}, nil},
 		{"custom", []string{"cis-aks-t1.2.0", "nsa"}, []string{"cis-aks-t1.2.0", "nsa"}},
+		{"strips blanks", []string{"", "nsa", " "}, []string{"nsa"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -275,4 +277,3 @@ func TestDefaultFrameworks(t *testing.T) {
 		})
 	}
 }
-

--- a/docs/features/default-frameworks.md
+++ b/docs/features/default-frameworks.md
@@ -1,0 +1,27 @@
+# Default posture frameworks
+
+## Overview
+
+Install-time `defaultFrameworks` in `clusterData` controls which frameworks the
+operator uses when a posture scan does not name targets explicitly.
+
+## Precedence
+
+1. **Explicit request** — `scanV1.targetNames` / API payload with non-blank names
+2. **`defaultFrameworks`** — from Helm / `clusterData` (when non-empty)
+3. **Legacy fallback**
+   - empty `scanV1` / continuous scan → `["all"]`
+   - startup scan / exception rescan → `["allcontrols", "nsa", "mitre"]`
+
+Blank entries in `targetNames` (e.g. `[""]`) are treated as absent and fall
+through to step 2/3.
+
+## Continuous scanning
+
+Continuous scanning builds requests with no `TargetType` / `TargetNames`. Those
+scans intentionally inherit the same defaults as an empty `scanV1`.
+
+## Helm
+
+See the kubescape-operator chart `defaultFrameworks` value. Requires an operator
+image that includes this feature.

--- a/main.go
+++ b/main.go
@@ -21,12 +21,12 @@ import (
 	"github.com/kubescape/node-agent/pkg/cloudmetadata"
 	"github.com/kubescape/node-agent/pkg/rulebindingmanager"
 	"github.com/kubescape/node-agent/pkg/watcher/dynamicwatcher"
-	exporters "github.com/kubescape/operator/admission/exporter"
 	admissioncel "github.com/kubescape/operator/admission/cel"
-	celrules "github.com/kubescape/operator/admission/rules/cel"
+	exporters "github.com/kubescape/operator/admission/exporter"
 	rulebindingcachev1 "github.com/kubescape/operator/admission/rulebinding/cache"
-	"github.com/kubescape/operator/admission/ruleswatcher"
+	celrules "github.com/kubescape/operator/admission/rules/cel"
 	"github.com/kubescape/operator/admission/rulesupdate"
+	"github.com/kubescape/operator/admission/ruleswatcher"
 	"github.com/kubescape/operator/admission/webhook"
 	"github.com/kubescape/operator/config"
 	"github.com/kubescape/operator/mainhandler"
@@ -151,7 +151,10 @@ func main() {
 	}()
 
 	if components.Components.ServiceDiscovery.Enabled {
-		logger.L().Debug("triggering a full kubescapeScan on startup")
+		logger.L().Info("triggering a full kubescapeScan on startup",
+			helpers.Interface("defaultFrameworks", operatorConfig.DefaultFrameworks()),
+			helpers.Interface("effectiveFrameworks", utils.FrameworksOrDefault(operatorConfig.DefaultFrameworks(), utils.NativeDefaultFrameworks)),
+		)
 		go mainHandler.StartupTriggerActions(ctx, mainhandler.GetStartupActions(operatorConfig))
 	}
 

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -557,7 +557,7 @@ func GetStartupActions(config config.IConfig) []apis.Command {
 				utils.KubescapeScanV1: utilsmetav1.PostScanRequest{
 					HostScanner: boolutils.BoolPointer(false),
 					TargetType:  v1.KindFramework,
-					TargetNames: frameworksForFullClusterScan(config.DefaultFrameworks()),
+					TargetNames: utils.FrameworksOrDefault(config.DefaultFrameworks(), utils.NativeDefaultFrameworks),
 				},
 			},
 		},

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -557,7 +557,7 @@ func GetStartupActions(config config.IConfig) []apis.Command {
 				utils.KubescapeScanV1: utilsmetav1.PostScanRequest{
 					HostScanner: boolutils.BoolPointer(false),
 					TargetType:  v1.KindFramework,
-					TargetNames: []string{"allcontrols", "nsa", "mitre"},
+					TargetNames: frameworksForFullClusterScan(config.DefaultFrameworks()),
 				},
 			},
 		},

--- a/mainhandler/kubescapehandler.go
+++ b/mainhandler/kubescapehandler.go
@@ -93,7 +93,7 @@ func (actionHandler *ActionHandler) setKubescapeCronJob(ctx context.Context) err
 		return errors.New("KubescapeScheduler is not enabled")
 	}
 
-	req, err := getKubescapeRequest(actionHandler.sessionObj.Command.Args)
+	req, err := getKubescapeRequest(actionHandler.sessionObj.Command.Args, actionHandler.config.DefaultFrameworks())
 	if err != nil {
 		return err
 	}
@@ -162,7 +162,7 @@ func (actionHandler *ActionHandler) kubescapeScan(ctx context.Context) error {
 		return errors.New("kubescape is not enabled")
 	}
 
-	request, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args)
+	request, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, actionHandler.config.DefaultFrameworks())
 	if err != nil {
 		return err
 	}

--- a/mainhandler/kubescapehandlerhelper.go
+++ b/mainhandler/kubescapehandlerhelper.go
@@ -53,7 +53,7 @@ func getKubescapeV1ScanStatusURL(config config.IConfig, scanID string) *url.URL 
 	return &ksURL
 }
 
-func getKubescapeV1ScanRequest(args map[string]interface{}) (*utilsmetav1.PostScanRequest, error) {
+func getKubescapeV1ScanRequest(args map[string]interface{}, defaultFrameworks []string) (*utilsmetav1.PostScanRequest, error) {
 
 	scanV1, ok := args[utils.KubescapeScanV1]
 	if !ok {
@@ -69,8 +69,9 @@ func getKubescapeV1ScanRequest(args map[string]interface{}) (*utilsmetav1.PostSc
 	if err := json.Unmarshal(scanV1Bytes, postScanRequest); err != nil {
 		return nil, fmt.Errorf("failed to convert request to v1/scan object, reason: %s", err.Error())
 	}
+	// Explicit targetNames from the API / scanV1 payload take precedence over install-time defaults.
 	if len(postScanRequest.TargetNames) == 0 || postScanRequest.TargetType == "" {
-		setDefaultsKubescapeScanRequest(postScanRequest)
+		setDefaultsKubescapeScanRequest(postScanRequest, defaultFrameworks)
 	}
 
 	for i := range postScanRequest.TargetNames {
@@ -104,8 +105,8 @@ func readKubescapeV1ScanResponse(resp *http.Response) (*utilsmetav1.Response, er
 	return response, nil
 }
 
-func getKubescapeRequest(args map[string]interface{}) (*utilsmetav1.PostScanRequest, error) {
-	postScanRequest, err := getKubescapeV1ScanRequest(args)
+func getKubescapeRequest(args map[string]interface{}, defaultFrameworks []string) (*utilsmetav1.PostScanRequest, error) {
+	postScanRequest, err := getKubescapeV1ScanRequest(args, defaultFrameworks)
 	if err != nil {
 		return postScanRequest, err
 	}
@@ -114,7 +115,7 @@ func getKubescapeRequest(args map[string]interface{}) (*utilsmetav1.PostScanRequ
 	if err := validateKubescapeScanRequest(postScanRequest); err != nil {
 		return postScanRequest, err
 	}
-	setDefaultsKubescapeScanRequest(postScanRequest)
+	setDefaultsKubescapeScanRequest(postScanRequest, defaultFrameworks)
 
 	return postScanRequest, nil
 }
@@ -217,12 +218,27 @@ func validateKubescapeScanRequest(postScanRequest *utilsmetav1.PostScanRequest) 
 	return nil
 }
 
-func setDefaultsKubescapeScanRequest(postScanRequest *utilsmetav1.PostScanRequest) {
-	// set default scan to all
+func setDefaultsKubescapeScanRequest(postScanRequest *utilsmetav1.PostScanRequest, defaultFrameworks []string) {
 	if len(postScanRequest.TargetNames) == 0 {
-		postScanRequest.TargetNames = []string{"all"}
+		if len(defaultFrameworks) > 0 {
+			postScanRequest.TargetNames = append([]string(nil), defaultFrameworks...)
+		} else {
+			// Legacy fallback when clusterData has no defaultFrameworks.
+			postScanRequest.TargetNames = []string{"all"}
+		}
 		postScanRequest.TargetType = utilsapisv1.KindFramework
 	}
+}
+
+// nativeDefaultFrameworks is used for startup / exception rescans when
+// defaultFrameworks is not configured in clusterData.
+var nativeDefaultFrameworks = []string{"allcontrols", "nsa", "mitre"}
+
+func frameworksForFullClusterScan(defaultFrameworks []string) []string {
+	if len(defaultFrameworks) > 0 {
+		return append([]string(nil), defaultFrameworks...)
+	}
+	return append([]string(nil), nativeDefaultFrameworks...)
 }
 
 // appendSecurityFramework - append "security" framework to the request if targetType is "Framework"

--- a/mainhandler/kubescapehandlerhelper.go
+++ b/mainhandler/kubescapehandlerhelper.go
@@ -69,16 +69,17 @@ func getKubescapeV1ScanRequest(args map[string]interface{}, defaultFrameworks []
 	if err := json.Unmarshal(scanV1Bytes, postScanRequest); err != nil {
 		return nil, fmt.Errorf("failed to convert request to v1/scan object, reason: %s", err.Error())
 	}
-	// Explicit targetNames from the API / scanV1 payload take precedence over install-time defaults.
-	if len(postScanRequest.TargetNames) == 0 || postScanRequest.TargetType == "" {
-		setDefaultsKubescapeScanRequest(postScanRequest, defaultFrameworks)
-	}
 
-	for i := range postScanRequest.TargetNames {
-		if postScanRequest.TargetNames[i] == "" {
-			postScanRequest.TargetNames[i] = "all"
+	// Drop blank entries so targetNames: [""] is treated as "no explicit target".
+	names := make([]string, 0, len(postScanRequest.TargetNames))
+	for _, n := range postScanRequest.TargetNames {
+		if strings.TrimSpace(n) != "" {
+			names = append(names, n)
 		}
 	}
+	postScanRequest.TargetNames = names
+
+	setDefaultsKubescapeScanRequest(postScanRequest, defaultFrameworks)
 
 	return postScanRequest, nil
 }
@@ -219,26 +220,16 @@ func validateKubescapeScanRequest(postScanRequest *utilsmetav1.PostScanRequest) 
 }
 
 func setDefaultsKubescapeScanRequest(postScanRequest *utilsmetav1.PostScanRequest, defaultFrameworks []string) {
-	if len(postScanRequest.TargetNames) == 0 {
-		if len(defaultFrameworks) > 0 {
-			postScanRequest.TargetNames = append([]string(nil), defaultFrameworks...)
-		} else {
-			// Legacy fallback when clusterData has no defaultFrameworks.
-			postScanRequest.TargetNames = []string{"all"}
-		}
-		postScanRequest.TargetType = utilsapisv1.KindFramework
+	if len(postScanRequest.TargetNames) != 0 {
+		return
 	}
-}
-
-// nativeDefaultFrameworks is used for startup / exception rescans when
-// defaultFrameworks is not configured in clusterData.
-var nativeDefaultFrameworks = []string{"allcontrols", "nsa", "mitre"}
-
-func frameworksForFullClusterScan(defaultFrameworks []string) []string {
-	if len(defaultFrameworks) > 0 {
-		return append([]string(nil), defaultFrameworks...)
+	// Do not clobber non-framework target kinds (e.g. Control with empty names).
+	if postScanRequest.TargetType != "" && postScanRequest.TargetType != utilsapisv1.KindFramework {
+		return
 	}
-	return append([]string(nil), nativeDefaultFrameworks...)
+	// Legacy fallback when clusterData has no defaultFrameworks: empty scanV1 / continuous scan → "all".
+	postScanRequest.TargetNames = utils.FrameworksOrDefault(defaultFrameworks, []string{"all"})
+	postScanRequest.TargetType = utilsapisv1.KindFramework
 }
 
 // appendSecurityFramework - append "security" framework to the request if targetType is "Framework"

--- a/mainhandler/kubescapehandlerhelper_test.go
+++ b/mainhandler/kubescapehandlerhelper_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/armosec/armoapi-go/apis"
+	"github.com/armosec/armoapi-go/armotypes"
 	"github.com/armosec/utils-go/boolutils"
 	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
 	beUtils "github.com/kubescape/backend/pkg/utils"
@@ -52,6 +53,7 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
 	}
 	{
+		// blank targetNames with no defaults → legacy "all"
 		actionHandler := ActionHandler{
 			sessionObj: &utils.SessionObj{
 				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{"targetType": utilsapisv1.KindFramework, "targetNames": []string{""}}}},
@@ -60,6 +62,21 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "all", req.TargetNames[0])
+		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
+	}
+	{
+		// blank targetNames with defaults → defaultFrameworks (blocker 1)
+		actionHandler := ActionHandler{
+			sessionObj: &utils.SessionObj{
+				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{
+					"targetType":  utilsapisv1.KindFramework,
+					"targetNames": []string{""},
+				}}},
+			},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, []string{"cis-eks-t1.2.0", "nsa"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"cis-eks-t1.2.0", "nsa"}, req.TargetNames)
 		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
 	}
 	{
@@ -73,6 +90,89 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 		assert.Equal(t, []string{"cis-aks-t1.2.0"}, req.TargetNames)
 		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
 	}
+	{
+		// continuous-scan shape: no TargetType/TargetNames → inherits defaultFrameworks (blocker 2)
+		actionHandler := ActionHandler{
+			sessionObj: &utils.SessionObj{
+				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{
+					"hostScanner": false,
+				}}},
+			},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, []string{"cis-eks-t1.2.0"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"cis-eks-t1.2.0"}, req.TargetNames)
+		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
+	}
+	{
+		// explicit frameworks win over defaults
+		actionHandler := ActionHandler{
+			sessionObj: &utils.SessionObj{
+				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{
+					"targetType":  utilsapisv1.KindFramework,
+					"targetNames": []string{"nsa"},
+				}}},
+			},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, []string{"cis-eks-t1.2.0"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"nsa"}, req.TargetNames)
+	}
+	{
+		// Control + empty names must not be clobbered into Framework defaults
+		actionHandler := ActionHandler{
+			sessionObj: &utils.SessionObj{
+				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{
+					"targetType":  utilsapisv1.KindControl,
+					"targetNames": []string{},
+				}}},
+			},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, []string{"cis-eks-t1.2.0"})
+		assert.NoError(t, err)
+		assert.Empty(t, req.TargetNames)
+		assert.Equal(t, utilsapisv1.KindControl, req.TargetType)
+	}
+}
+
+func TestGetKubescapeRequestWithDefaults(t *testing.T) {
+	args := map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{}}
+	req, err := getKubescapeRequest(args, []string{"nsa", "mitre"})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"nsa", "mitre"}, req.TargetNames)
+	assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
+
+	// cron path must also respect the Control targetType gate
+	argsControl := map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{
+		"targetType":  utilsapisv1.KindControl,
+		"targetNames": []string{},
+	}}
+	reqControl, err := getKubescapeRequest(argsControl, []string{"cis-eks-t1.2.0"})
+	assert.NoError(t, err)
+	assert.Empty(t, reqControl.TargetNames)
+	assert.Equal(t, utilsapisv1.KindControl, reqControl.TargetType)
+}
+
+func TestGetStartupActions(t *testing.T) {
+	cfg := config.NewOperatorConfig(
+		config.CapabilitiesConfig{},
+		utilsmetadata.ClusterConfig{ClusterName: "c1", InstallationData: armotypes.InstallationData{DefaultFrameworks: []string{"nsa"}}},
+		&beUtils.Credentials{},
+		config.Config{},
+	)
+	cmds := GetStartupActions(cfg)
+	assert.Len(t, cmds, 1)
+	psr := cmds[0].Args[utils.KubescapeScanV1].(utilsmetav1.PostScanRequest)
+	assert.Equal(t, []string{"nsa"}, psr.TargetNames)
+
+	cfgEmpty := config.NewOperatorConfig(
+		config.CapabilitiesConfig{},
+		utilsmetadata.ClusterConfig{ClusterName: "c1"},
+		&beUtils.Credentials{},
+		config.Config{},
+	)
+	psrEmpty := GetStartupActions(cfgEmpty)[0].Args[utils.KubescapeScanV1].(utilsmetav1.PostScanRequest)
+	assert.Equal(t, utils.NativeDefaultFrameworks, psrEmpty.TargetNames)
 }
 
 func TestUpdateCronJobTemplate(t *testing.T) {

--- a/mainhandler/kubescapehandlerhelper_test.go
+++ b/mainhandler/kubescapehandlerhelper_test.go
@@ -26,7 +26,7 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 				},
 			},
 		}
-		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args)
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, 0, req)
 	}
@@ -36,7 +36,7 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{"format": "json"}}},
 			},
 		}
-		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args)
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "json", req.Format)
 	}
@@ -46,7 +46,7 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{}}},
 			},
 		}
-		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args)
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "all", req.TargetNames[0])
 		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
@@ -57,9 +57,20 @@ func TestGetKubescapeV1ScanRequest(t *testing.T) {
 				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{"targetType": utilsapisv1.KindFramework, "targetNames": []string{""}}}},
 			},
 		}
-		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args)
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "all", req.TargetNames[0])
+		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
+	}
+	{
+		actionHandler := ActionHandler{
+			sessionObj: &utils.SessionObj{
+				Command: &apis.Command{Args: map[string]interface{}{utils.KubescapeScanV1: map[string]interface{}{}}},
+			},
+		}
+		req, err := getKubescapeV1ScanRequest(actionHandler.sessionObj.Command.Args, []string{"cis-aks-t1.2.0"})
+		assert.NoError(t, err)
+		assert.Equal(t, []string{"cis-aks-t1.2.0"}, req.TargetNames)
 		assert.Equal(t, utilsapisv1.KindFramework, req.TargetType)
 	}
 }

--- a/utils/frameworks.go
+++ b/utils/frameworks.go
@@ -1,0 +1,16 @@
+package utils
+
+import "slices"
+
+// NativeDefaultFrameworks is the legacy posture framework set used for
+// full-cluster scans (startup, exception rescan) when clusterData has no
+// defaultFrameworks.
+var NativeDefaultFrameworks = []string{"allcontrols", "nsa", "mitre"}
+
+// FrameworksOrDefault returns a copy of frameworks, or of fallback when empty.
+func FrameworksOrDefault(frameworks, fallback []string) []string {
+	if len(frameworks) > 0 {
+		return slices.Clone(frameworks)
+	}
+	return slices.Clone(fallback)
+}

--- a/utils/frameworks_test.go
+++ b/utils/frameworks_test.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrameworksOrDefault(t *testing.T) {
+	assert.Equal(t, []string{"nsa"}, FrameworksOrDefault([]string{"nsa"}, NativeDefaultFrameworks))
+	assert.Equal(t, NativeDefaultFrameworks, FrameworksOrDefault(nil, NativeDefaultFrameworks))
+	assert.Equal(t, NativeDefaultFrameworks, FrameworksOrDefault([]string{}, NativeDefaultFrameworks))
+
+	got := FrameworksOrDefault([]string{"nsa"}, NativeDefaultFrameworks)
+	got[0] = "mutated"
+	assert.Equal(t, []string{"nsa"}, FrameworksOrDefault([]string{"nsa"}, NativeDefaultFrameworks))
+}

--- a/watcher/securityexceptionwatcher.go
+++ b/watcher/securityexceptionwatcher.go
@@ -378,16 +378,6 @@ func (wh *SecurityExceptionWatchHandler) forgetExpired(obj *unstructured.Unstruc
 	wh.mu.Unlock()
 }
 
-// nativeDefaultFrameworks matches mainhandler when clusterData has no defaultFrameworks.
-var nativeDefaultFrameworks = []string{"allcontrols", "nsa", "mitre"}
-
-func frameworksOrNativeDefaults(defaultFrameworks []string) []string {
-	if len(defaultFrameworks) > 0 {
-		return append([]string(nil), defaultFrameworks...)
-	}
-	return append([]string(nil), nativeDefaultFrameworks...)
-}
-
 // buildRescanCommand returns the cluster-wide posture rescan command, matching
 // the operator's startup full scan.
 func buildRescanCommand(clusterName string, defaultFrameworks []string) *apis.Command {
@@ -398,7 +388,7 @@ func buildRescanCommand(clusterName string, defaultFrameworks []string) *apis.Co
 			utils.KubescapeScanV1: utilsmetav1.PostScanRequest{
 				HostScanner: boolutils.BoolPointer(false),
 				TargetType:  v1.KindFramework,
-				TargetNames: frameworksOrNativeDefaults(defaultFrameworks),
+				TargetNames: utils.FrameworksOrDefault(defaultFrameworks, utils.NativeDefaultFrameworks),
 			},
 		},
 	}

--- a/watcher/securityexceptionwatcher.go
+++ b/watcher/securityexceptionwatcher.go
@@ -266,7 +266,7 @@ func (wh *SecurityExceptionWatchHandler) rescanLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-wh.rescanSignal:
-			cmd := buildRescanCommand(wh.cfg.ClusterName())
+			cmd := buildRescanCommand(wh.cfg.ClusterName(), wh.cfg.DefaultFrameworks())
 			if err := wh.dispatchRescan(ctx, cmd); err != nil {
 				// Re-arm so a transient failure (e.g. the shared worker pool is
 				// overloaded and Invoke returns ErrPoolOverload) is retried after
@@ -378,9 +378,19 @@ func (wh *SecurityExceptionWatchHandler) forgetExpired(obj *unstructured.Unstruc
 	wh.mu.Unlock()
 }
 
+// nativeDefaultFrameworks matches mainhandler when clusterData has no defaultFrameworks.
+var nativeDefaultFrameworks = []string{"allcontrols", "nsa", "mitre"}
+
+func frameworksOrNativeDefaults(defaultFrameworks []string) []string {
+	if len(defaultFrameworks) > 0 {
+		return append([]string(nil), defaultFrameworks...)
+	}
+	return append([]string(nil), nativeDefaultFrameworks...)
+}
+
 // buildRescanCommand returns the cluster-wide posture rescan command, matching
 // the operator's startup full scan.
-func buildRescanCommand(clusterName string) *apis.Command {
+func buildRescanCommand(clusterName string, defaultFrameworks []string) *apis.Command {
 	return &apis.Command{
 		CommandName: apis.TypeRunKubescape,
 		WildWlid:    pkgwlid.GetK8sWLID(clusterName, "", "", ""),
@@ -388,7 +398,7 @@ func buildRescanCommand(clusterName string) *apis.Command {
 			utils.KubescapeScanV1: utilsmetav1.PostScanRequest{
 				HostScanner: boolutils.BoolPointer(false),
 				TargetType:  v1.KindFramework,
-				TargetNames: []string{"allcontrols", "nsa", "mitre"},
+				TargetNames: frameworksOrNativeDefaults(defaultFrameworks),
 			},
 		},
 	}

--- a/watcher/securityexceptionwatcher_test.go
+++ b/watcher/securityexceptionwatcher_test.go
@@ -98,7 +98,7 @@ func recordingHandler(t *testing.T, objs ...runtime.Object) (*SecurityExceptionW
 }
 
 func TestBuildRescanCommand(t *testing.T) {
-	cmd := buildRescanCommand(testClusterName)
+	cmd := buildRescanCommand(testClusterName, nil)
 
 	assert.Equal(t, apis.TypeRunKubescape, cmd.CommandName)
 	assert.Equal(t, pkgwlid.GetK8sWLID(testClusterName, "", "", ""), cmd.WildWlid)
@@ -110,6 +110,16 @@ func TestBuildRescanCommand(t *testing.T) {
 	assert.ElementsMatch(t, []string{"allcontrols", "nsa", "mitre"}, psr.TargetNames)
 	require.NotNil(t, psr.HostScanner)
 	assert.False(t, *psr.HostScanner)
+}
+
+func TestBuildRescanCommandCustomFrameworks(t *testing.T) {
+	cmd := buildRescanCommand(testClusterName, []string{"cis-aks-t1.2.0"})
+
+	raw, ok := cmd.Args[utils.KubescapeScanV1]
+	require.True(t, ok)
+	psr, ok := raw.(utilsmetav1.PostScanRequest)
+	require.True(t, ok)
+	assert.Equal(t, []string{"cis-aks-t1.2.0"}, psr.TargetNames)
 }
 
 func TestParseExpiresAt(t *testing.T) {


### PR DESCRIPTION
## Overview
This PR adds support for install-time `defaultFrameworks` from `clusterData`, so posture scans that omit explicit targets use the Helm-configured framework list instead of hardcoded / `"all"` defaults.


Fixes https://github.com/kubescape/helm-charts/issues/566

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

## Additional Information

- Field already exists on `InstallationData` in armoapi-go (`DefaultFrameworks []string`).
- Helm chart PR (separate) renders `defaultFrameworks` into `ks-cloud-config` / `clusterData`.
- Release note: safe if the field is missing — legacy fallbacks remain (`"all"` for empty scanV1, native trio for startup/exception rescans).

## How to Test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable default posture frameworks through cluster configuration and Helm.
  * Startup, scheduled, direct, continuous, and rescan scans now honor configured frameworks.
  * Explicit scan targets take precedence over configured defaults.
  * Blank framework names are ignored, with native defaults used when none are configured.

* **Documentation**
  * Added guidance covering configuration, precedence, continuous scans, and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->