### PR TITLE
fix(rulebinding): match namespaces by exact name, not String() substring

### DIFF
--- a/admission/rulebinding/cache/cache.go
+++ b/admission/rulebinding/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"context"
-	"strings"
 
 	"github.com/goradd/maps"
 	"github.com/kubescape/go-logger"
@@ -96,14 +95,22 @@ func (c *RBCache) ListRulesForObject(ctx context.Context, object *unstructured.U
 		}
 
 		// check pod selectors
-		podSelector, _ := metav1.LabelSelectorAsSelector(&rb.Spec.PodSelector)
+		podSelector, err := metav1.LabelSelectorAsSelector(&rb.Spec.PodSelector)
+		if err != nil {
+			logger.L().Error("failed to parse pod selector", helpers.String("ruleBiding", uniqueName(&rb)), helpers.Error(err))
+			continue
+		}
 		if !podSelector.Matches(labels.Set(object.GetLabels())) {
 			// pod selectors doesnt match
 			continue
 		}
 
 		// check namespace selectors
-		nsSelector, _ := metav1.LabelSelectorAsSelector(&rb.Spec.NamespaceSelector)
+		nsSelector, err := metav1.LabelSelectorAsSelector(&rb.Spec.NamespaceSelector)
+		if err != nil {
+			logger.L().Error("failed to parse namespace selector", helpers.String("ruleBiding", uniqueName(&rb)), helpers.Error(err))
+			continue
+		}
 		nsSelectorStr := nsSelector.String()
 		if len(nsSelectorStr) != 0 {
 			// get related namespaces
@@ -112,7 +119,7 @@ func (c *RBCache) ListRulesForObject(ctx context.Context, object *unstructured.U
 				logger.L().Error("failed to list namespaces", helpers.String("ruleBiding", uniqueName(&rb)), helpers.String("nsSelector", nsSelectorStr), helpers.Error(err))
 				continue
 			}
-			if !strings.Contains(namespaces.String(), object.GetNamespace()) {
+			if !namespaceListHasName(namespaces, object.GetNamespace()) {
 				// namespace selectors dont match
 				continue
 			}

--- a/admission/rulebinding/cache/helpers.go
+++ b/admission/rulebinding/cache/helpers.go
@@ -4,10 +4,26 @@ import (
 	typesv1 "github.com/kubescape/node-agent/pkg/rulebindingmanager/types/v1"
 	"github.com/kubescape/node-agent/pkg/utils"
 	"github.com/kubescape/node-agent/pkg/watcher"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 )
+
+// namespaceListHasName reports whether name is an exact member of list.Items.
+// Do not use strings.Contains(list.String(), name): NamespaceList.String() is a
+// debug dump, so substrings (e.g. "dev" in "devel") falsely match.
+func namespaceListHasName(list *corev1.NamespaceList, name string) bool {
+	if list == nil {
+		return false
+	}
+	for i := range list.Items {
+		if list.Items[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
 
 // ruleBindingKind is the Kind value the CRD reports for RuntimeAlertRuleBinding
 // objects. The dynamic watcher dispatches events from all watched GVRs to every

--- a/admission/rulebinding/cache/helpers_test.go
+++ b/admission/rulebinding/cache/helpers_test.go
@@ -10,6 +10,25 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+func TestNamespaceListHasName(t *testing.T) {
+	list := &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{ObjectMeta: metav1.ObjectMeta{Name: "devel"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "production"}},
+		},
+	}
+
+	assert.True(t, namespaceListHasName(list, "devel"))
+	assert.True(t, namespaceListHasName(list, "production"))
+	// Substring of "devel" / "production" must not match (regression for
+	// strings.Contains(namespaces.String(), ns)).
+	assert.False(t, namespaceListHasName(list, "dev"))
+	assert.False(t, namespaceListHasName(list, "prod"))
+	assert.False(t, namespaceListHasName(list, "missing"))
+	assert.False(t, namespaceListHasName(nil, "devel"))
+	assert.False(t, namespaceListHasName(&corev1.NamespaceList{}, "devel"))
+}
+
 func TestResourcesToWatch(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Overview
fixes #401
This PR fixes false-positive rulebinding matches when a namespace name is a substring of another (e.g. `dev` matching `devel`).

Namespace membership now checks exact names instead of `strings.Contains(namespaces.String(), …)`. Invalid label selectors are skipped.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

## How to Test
1. Label `devel` with `repro=selected`; leave `dev` unlabeled.
2. Bind rule `R2002` with that namespace selector.
3. Create pods in both namespaces — only `devel` should match.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rule-binding label selector handling by reporting conversion errors and skipping invalid bindings.
  * Fixed namespace matching to require exact names, preventing unintended matches from partial or substring values.
  * Added safer handling for empty or unavailable namespace lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->