### PR TITLE
Honour continuousScanning.matchingRules.namespaces

### DIFF
--- a/continuousscanning/loader.go
+++ b/continuousscanning/loader.go
@@ -36,6 +36,7 @@ type targetLoader struct {
 
 type TargetLoader interface {
 	LoadGVRs(ctx context.Context) []schema.GroupVersionResource
+	LoadNamespaces(ctx context.Context) []string
 }
 
 // NewTargetLoader returns a new Target Loader
@@ -74,6 +75,19 @@ func (l *targetLoader) LoadGVRs(ctx context.Context) []schema.GroupVersionResour
 	}
 
 	return gvrs
+}
+
+// LoadNamespaces loads the namespaces the matching rules restrict watches to.
+//
+// An empty result means every namespace, which is what a rule set that
+// omits the field asks for.
+func (l *targetLoader) LoadNamespaces(ctx context.Context) []string {
+	rules, err := l.fetcher.Fetch(ctx)
+	if err != nil || rules == nil {
+		return nil
+	}
+
+	return rules.Namespaces
 }
 
 type fileFetcher struct {

--- a/continuousscanning/loader_test.go
+++ b/continuousscanning/loader_test.go
@@ -189,3 +189,48 @@ func TestTargetLoader(t *testing.T) {
 	}
 
 }
+
+func TestTargetLoaderLoadNamespaces(t *testing.T) {
+	tt := []struct {
+		name               string
+		inputMatchingRules *MatchingRules
+		wantNamespaces     []string
+	}{
+		{
+			name: "the configured namespaces are returned",
+			inputMatchingRules: &MatchingRules{
+				APIResources: []APIResourceMatch{
+					{
+						Groups:    []string{"apps"},
+						Versions:  []string{"v1"},
+						Resources: []string{"deployments"},
+					},
+				},
+				Namespaces: []string{"default", "kube-system"},
+			},
+			wantNamespaces: []string{"default", "kube-system"},
+		},
+		{
+			name: "no namespaces means every namespace",
+			inputMatchingRules: &MatchingRules{
+				APIResources: []APIResourceMatch{
+					{
+						Groups:    []string{"apps"},
+						Versions:  []string{"v1"},
+						Resources: []string{"deployments"},
+					},
+				},
+			},
+			wantNamespaces: nil,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			l := NewTargetLoader(&stubFetcher{tc.inputMatchingRules})
+
+			assert.Equal(t, tc.wantNamespaces, l.LoadNamespaces(ctx))
+		})
+	}
+}

--- a/continuousscanning/service.go
+++ b/continuousscanning/service.go
@@ -30,8 +30,9 @@ func (s *ContinuousScanningService) listen(ctx context.Context) <-chan armoapi.C
 	resourceEventsCh := make(chan watch.Event, 100)
 
 	gvrs := s.tl.LoadGVRs(ctx)
-	logger.L().Info("fetched gvrs", helpers.Interface("gvrs", gvrs))
-	wp, _ := NewWatchPool(ctx, s.k8sdynamic, gvrs, listOpts)
+	namespaces := s.tl.LoadNamespaces(ctx)
+	logger.L().Info("fetched gvrs", helpers.Interface("gvrs", gvrs), helpers.Interface("namespaces", namespaces))
+	wp, _ := NewWatchPool(ctx, s.k8sdynamic, gvrs, namespaces, listOpts)
 	wp.Run(ctx, resourceEventsCh)
 	logger.L().Info("ran watch pool")
 

--- a/continuousscanning/watchbuilder.go
+++ b/continuousscanning/watchbuilder.go
@@ -13,11 +13,16 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-func NewDynamicWatch(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, opts metav1.ListOptions) (watch.Interface, error) {
+// NewDynamicWatch starts a watch for the given GVR.
+//
+// namespace restricts a namespace-scoped resource to that namespace. An
+// empty namespace watches all of them. A cluster-scoped resource ignores
+// it, since there is nothing to scope.
+func NewDynamicWatch(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 	var w watch.Interface
 	var err error
 	if k8sinterface.IsNamespaceScope(&gvr) {
-		w, err = client.Resource(gvr).Namespace("").Watch(ctx, opts)
+		w, err = client.Resource(gvr).Namespace(namespace).Watch(ctx, opts)
 	} else {
 		w, err = client.Resource(gvr).Watch(ctx, opts)
 	}
@@ -28,14 +33,16 @@ type SelfHealingWatch struct {
 	opts          metav1.ListOptions
 	client        dynamic.Interface
 	currWatch     watch.Interface
-	makeWatchFunc func(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, opts metav1.ListOptions) (watch.Interface, error)
+	makeWatchFunc func(ctx context.Context, client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) (watch.Interface, error)
 	gvr           schema.GroupVersionResource
+	namespace     string
 }
 
-func NewSelfHealingWatch(client dynamic.Interface, gvr schema.GroupVersionResource, opts metav1.ListOptions) *SelfHealingWatch {
+func NewSelfHealingWatch(client dynamic.Interface, gvr schema.GroupVersionResource, namespace string, opts metav1.ListOptions) *SelfHealingWatch {
 	return &SelfHealingWatch{
 		client:        client,
 		gvr:           gvr,
+		namespace:     namespace,
 		opts:          opts,
 		makeWatchFunc: NewDynamicWatch,
 	}
@@ -67,7 +74,7 @@ func (w *SelfHealingWatch) Run(ctx context.Context, readyWg *sync.WaitGroup, out
 		default:
 			gvr := helpers.String("gvr", w.gvr.String())
 			logger.L().Debug("creating watch for GVR", gvr)
-			watchFunc, err := w.makeWatchFunc(ctx, w.client, w.gvr, w.opts)
+			watchFunc, err := w.makeWatchFunc(ctx, w.client, w.gvr, w.namespace, w.opts)
 			if err != nil {
 				logger.L().Ctx(ctx).Warning(
 					"got error when creating a watch for gvr",
@@ -109,14 +116,22 @@ func (wp *WatchPool) Run(ctx context.Context, out chan<- watch.Event) {
 	logger.L().Info("Watch pool: started ok")
 }
 
-func NewWatchPool(_ context.Context, client dynamic.Interface, gvrs []schema.GroupVersionResource, opts metav1.ListOptions) (*WatchPool, error) {
-	watches := make([]*SelfHealingWatch, len(gvrs))
+// NewWatchPool builds one watch per GVR per namespace.
+//
+// An empty namespaces slice keeps the previous behaviour of a single watch
+// per GVR across the whole cluster.
+func NewWatchPool(_ context.Context, client dynamic.Interface, gvrs []schema.GroupVersionResource, namespaces []string, opts metav1.ListOptions) (*WatchPool, error) {
+	if len(namespaces) == 0 {
+		namespaces = []string{""}
+	}
+
+	watches := make([]*SelfHealingWatch, 0, len(gvrs)*len(namespaces))
 
 	for idx := range gvrs {
 		gvr := gvrs[idx]
-		selfHealingWatch := NewSelfHealingWatch(client, gvr, opts)
-
-		watches[idx] = selfHealingWatch
+		for _, namespace := range namespaces {
+			watches = append(watches, NewSelfHealingWatch(client, gvr, namespace, opts))
+		}
 	}
 
 	pool := &WatchPool{pool: watches}

--- a/continuousscanning/watchbuilder.go
+++ b/continuousscanning/watchbuilder.go
@@ -116,7 +116,11 @@ func (wp *WatchPool) Run(ctx context.Context, out chan<- watch.Event) {
 	logger.L().Info("Watch pool: started ok")
 }
 
-// NewWatchPool builds one watch per GVR per namespace.
+// NewWatchPool builds one watch per namespaced GVR per namespace.
+//
+// A cluster-scoped GVR gets exactly one watch whatever the namespace list
+// says, because its watch covers the cluster already: fanning it out would
+// create identical watches all feeding the same channel.
 //
 // An empty namespaces slice keeps the previous behaviour of a single watch
 // per GVR across the whole cluster.
@@ -125,11 +129,19 @@ func NewWatchPool(_ context.Context, client dynamic.Interface, gvrs []schema.Gro
 		namespaces = []string{""}
 	}
 
+	clusterScoped := []string{""}
+
 	watches := make([]*SelfHealingWatch, 0, len(gvrs)*len(namespaces))
 
 	for idx := range gvrs {
 		gvr := gvrs[idx]
-		for _, namespace := range namespaces {
+
+		watchNamespaces := namespaces
+		if !k8sinterface.IsNamespaceScope(&gvr) {
+			watchNamespaces = clusterScoped
+		}
+
+		for _, namespace := range watchNamespaces {
 			watches = append(watches, NewSelfHealingWatch(client, gvr, namespace, opts))
 		}
 	}

--- a/continuousscanning/watchbuilder_test.go
+++ b/continuousscanning/watchbuilder_test.go
@@ -12,7 +12,7 @@ import (
 	ktest "k8s.io/client-go/testing"
 )
 
-func assertWatchAction(t *testing.T, gotAction ktest.Action, wantGVR schema.GroupVersionResource) {
+func assertWatchAction(t *testing.T, gotAction ktest.Action, wantGVR schema.GroupVersionResource, wantNamespace string) {
 	t.Helper()
 	gotAction, ok := gotAction.(ktest.WatchActionImpl)
 	assert.Equalf(t, true, ok, "incorrect action type, expecting watch")
@@ -21,16 +21,19 @@ func assertWatchAction(t *testing.T, gotAction ktest.Action, wantGVR schema.Grou
 		gotGvr := gotAction.GetResource()
 
 		assert.Equalf(t, wantGVR, gotGvr, "GVR mismatch")
+		assert.Equalf(t, wantNamespace, gotAction.GetNamespace(), "namespace mismatch")
 	}
 
 }
 
 func TestNewDynamicWatch(t *testing.T) {
 	tt := []struct {
-		wantErr     error
-		inputGVR    schema.GroupVersionResource
-		name        string
-		wantActions []ktest.Action
+		wantErr        error
+		inputGVR       schema.GroupVersionResource
+		name           string
+		inputNamespace string
+		wantNamespace  string
+		wantActions    []ktest.Action
 	}{
 		{
 			name: "",
@@ -42,6 +45,18 @@ func TestNewDynamicWatch(t *testing.T) {
 			wantActions: []ktest.Action{},
 			wantErr:     nil,
 		},
+		{
+			name: "a namespace is passed through to the watch",
+			inputGVR: schema.GroupVersionResource{
+				Group:    "apps",
+				Version:  "v1",
+				Resource: "deployments",
+			},
+			inputNamespace: "kube-system",
+			wantNamespace:  "kube-system",
+			wantActions:    []ktest.Action{},
+			wantErr:        nil,
+		},
 	}
 
 	for _, tc := range tt {
@@ -50,12 +65,60 @@ func TestNewDynamicWatch(t *testing.T) {
 			opts := metav1.ListOptions{}
 			dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
 
-			_, gotErr := NewDynamicWatch(ctx, dynClient, tc.inputGVR, opts)
+			_, gotErr := NewDynamicWatch(ctx, dynClient, tc.inputGVR, tc.inputNamespace, opts)
 
 			gotActions := dynClient.Actions()
 
-			assertWatchAction(t, gotActions[0], tc.inputGVR)
+			assertWatchAction(t, gotActions[0], tc.inputGVR, tc.wantNamespace)
 			assert.ErrorIs(t, gotErr, tc.wantErr)
+		})
+	}
+}
+
+func TestNewWatchPoolNamespaces(t *testing.T) {
+	gvrs := []schema.GroupVersionResource{
+		{Group: "apps", Version: "v1", Resource: "deployments"},
+		{Group: "", Version: "v1", Resource: "pods"},
+	}
+
+	tt := []struct {
+		name            string
+		inputNamespaces []string
+		wantWatches     int
+	}{
+		{
+			name:            "no namespaces keeps one watch per gvr",
+			inputNamespaces: nil,
+			wantWatches:     2,
+		},
+		{
+			name:            "each namespace gets its own watch per gvr",
+			inputNamespaces: []string{"default", "kube-system"},
+			wantWatches:     4,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+			pool, err := NewWatchPool(ctx, dynClient, gvrs, tc.inputNamespaces, metav1.ListOptions{})
+
+			assert.NoError(t, err)
+			assert.Len(t, pool.pool, tc.wantWatches)
+
+			gotNamespaces := map[string]int{}
+			for _, w := range pool.pool {
+				gotNamespaces[w.namespace]++
+			}
+			if len(tc.inputNamespaces) == 0 {
+				assert.Equal(t, map[string]int{"": len(gvrs)}, gotNamespaces)
+				return
+			}
+			for _, namespace := range tc.inputNamespaces {
+				assert.Equalf(t, len(gvrs), gotNamespaces[namespace], "namespace %q", namespace)
+			}
 		})
 	}
 }

--- a/continuousscanning/watchbuilder_test.go
+++ b/continuousscanning/watchbuilder_test.go
@@ -122,3 +122,60 @@ func TestNewWatchPoolNamespaces(t *testing.T) {
 		})
 	}
 }
+
+func TestNewWatchPoolClusterScopedGVRs(t *testing.T) {
+	clusterRoles := schema.GroupVersionResource{
+		Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "clusterroles",
+	}
+	nodes := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}
+	deployments := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+
+	tt := []struct {
+		name            string
+		inputGVRs       []schema.GroupVersionResource
+		inputNamespaces []string
+		wantWatches     int
+		wantNamespaces  map[string]int
+	}{
+		{
+			name:            "a cluster scoped gvr gets one watch whatever the namespaces say",
+			inputGVRs:       []schema.GroupVersionResource{clusterRoles, nodes},
+			inputNamespaces: []string{"default", "kube-system", "kubescape"},
+			wantWatches:     2,
+			wantNamespaces:  map[string]int{"": 2},
+		},
+		{
+			name:            "a mixed rule set fans out only the namespaced gvr",
+			inputGVRs:       []schema.GroupVersionResource{clusterRoles, deployments},
+			inputNamespaces: []string{"default", "kube-system"},
+			// one for clusterroles, two for deployments
+			wantWatches:    3,
+			wantNamespaces: map[string]int{"": 1, "default": 1, "kube-system": 1},
+		},
+		{
+			name:            "a cluster scoped gvr with no namespaces is unchanged",
+			inputGVRs:       []schema.GroupVersionResource{clusterRoles},
+			inputNamespaces: nil,
+			wantWatches:     1,
+			wantNamespaces:  map[string]int{"": 1},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+
+			pool, err := NewWatchPool(ctx, dynClient, tc.inputGVRs, tc.inputNamespaces, metav1.ListOptions{})
+
+			assert.NoError(t, err)
+			assert.Len(t, pool.pool, tc.wantWatches)
+
+			gotNamespaces := map[string]int{}
+			for _, w := range pool.pool {
+				gotNamespaces[w.namespace]++
+			}
+			assert.Equal(t, tc.wantNamespaces, gotNamespaces)
+		})
+	}
+}


### PR DESCRIPTION
Closes #397.

`MatchingRules.Namespaces` is declared and unmarshalled (`continuousscanning/loader.go:24`) and then never read. `LoadGVRs` takes `.APIResources` and nothing else, and `LoadGVRs` was the entire `TargetLoader` interface, so the namespace list had nowhere to go. `NewDynamicWatch` then hardcoded `Namespace("")`, so continuous scanning watched every GVR across the whole cluster regardless of what was configured.

That matters because the Helm chart ships a `namespaces` list in its defaults and documents it as functional:

```yaml
continuousScanning:
  matchingRules:
    match:
      - apiGroups: ["apps"]
        apiVersions: ["v1"]
        resources: ["deployments"]
    namespaces:
      - default
```

so it reads as namespace scoping that quietly does nothing. The only namespace filtering that actually happened is `cfg.SkipNamespace` in `service.go:47`, which is the unrelated global exclude list.

The change adds `LoadNamespaces` to `TargetLoader`, threads it from `service.listen` into `NewWatchPool`, and builds one watch per GVR per namespace. Two things kept deliberately unchanged:

- Cluster-scoped resources still ignore the namespace, via the existing `k8sinterface.IsNamespaceScope` branch, since there is nothing to scope.
- An empty or absent list still means every namespace, so any rule set that omits the field behaves exactly as it does now. That is the case the `no namespaces keeps one watch per gvr` test pins.

Tests: `TestNewWatchPoolNamespaces` covers both the empty case and the fan-out (2 GVRs by 2 namespaces gives 4 watches, one per pair), `TestNewDynamicWatch` gains a case asserting the namespace reaches the recorded watch action on the fake client, and `TestTargetLoaderLoadNamespaces` covers the loader in both shapes. `assertWatchAction` now checks the namespace as well as the GVR, which is what makes the first of those meaningful.

`go build ./continuousscanning/...`, `go vet ./continuousscanning/...` and `go test ./continuousscanning/...` are clean. A whole-repo `go build ./...` does not complete on macOS: `inspektor-gadget/pkg/utils/host` is Linux-only and excluded by build constraints here. That is pre-existing and unrelated to this change, but it does mean I have not built the packages that depend on it, so CI is the real check for those.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added namespace-aware continuous scanning for supported resources.
  * Scans can now target specific namespaces or retain cluster-wide coverage when none are configured.
  * Watch pools create separate watches for each configured namespace.
  * Cluster-scoped resources continue to be monitored independently of namespace settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->