### PR TITLE
fix: log the actual kubescape response body on scan errors

### DIFF
--- a/mainhandler/kubescapehandlerhelper.go
+++ b/mainhandler/kubescapehandlerhelper.go
@@ -90,13 +90,14 @@ func readKubescapeV1ScanResponse(resp *http.Response) (*utilsmetav1.Response, er
 		return response, nil
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return response, fmt.Errorf("received status code '%d' from kubescape, body: %s", resp.StatusCode, resp.Body)
-	}
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return response, fmt.Errorf("received status code '%d' from kubescape, body: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	if err := json.Unmarshal(bodyBytes, response); err != nil {

--- a/mainhandler/kubescapehandlerhelper_test.go
+++ b/mainhandler/kubescapehandlerhelper_test.go
@@ -1,6 +1,8 @@
 package mainhandler
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -255,4 +257,22 @@ func TestAppendSecurityFramework(t *testing.T) {
 		})
 	}
 
+}
+
+func TestReadKubescapeV1ScanResponseIncludesBodyOnError(t *testing.T) {
+	// A real *http.Response is required here, not a hand-built one: resp.Body's
+	// concrete type behind the io.ReadCloser interface matters for what %s used
+	// to print, and only a genuine transport-produced body reproduces that.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("scan queue is full"))
+	}))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	assert.NoError(t, err)
+
+	_, err = readKubescapeV1ScanResponse(resp)
+
+	assert.ErrorContains(t, err, "scan queue is full")
 }


### PR DESCRIPTION
`readKubescapeV1ScanResponse` builds its error with `fmt.Errorf("...body: %s", resp.StatusCode, resp.Body)` when the scan endpoint returns a non-200. `resp.Body` is an `io.ReadCloser`, so `%s` never prints the actual response text — it prints Go's reflection dump of the internal `*http.body` struct instead, which is useless for figuring out why kubescape rejected the scan.

Moved the `io.ReadAll` above the status check (it already happens on the success path) and used the bytes in the error message instead. Added a test against a real `httptest` server so it actually exercises the concrete `resp.Body` type instead of a hand-built one that would mask this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for failed scan responses by including details returned by the server.
  * Ensured response-reading errors are reported clearly before validating the HTTP status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->