### PR TITLE
fix(remediation): honour selector.namespace when resolving findings-driven targets

### DIFF
--- a/mainhandler/findings.go
+++ b/mainhandler/findings.go
@@ -50,7 +50,8 @@ func severityRank(severity string) (int, bool) {
 // No re-scan happens: it acts on findings already in the cluster.
 //
 // A summary matches when it fails the requested Control and/or carries a failing
-// finding at or above MinSeverity (see summaryMatchesSelector). Targets in
+// finding at or above MinSeverity (see summaryMatchesSelector), and, when the
+// selector names a Namespace, when it resolves to a workload in it. Targets in
 // excluded/protected namespaces and non-remediable kinds are dropped here so
 // they never reach a remediator, and duplicates are collapsed.
 func (actionHandler *ActionHandler) resolveSelectorTargets(ctx context.Context, selector *apis.OperatorActionSelector) ([]remediators.Target, error) {
@@ -73,8 +74,11 @@ func (actionHandler *ActionHandler) resolveSelectorTargets(ctx context.Context, 
 		return nil, fmt.Errorf("operatorAction: findings-driven targeting requires the storage client, which is not configured")
 	}
 
-	// namespace "" lists configuration-scan summaries across all namespaces.
-	summaries, err := actionHandler.ksStorageClient.SpdxV1beta1().WorkloadConfigurationScanSummaries("").List(ctx, metav1.ListOptions{})
+	// Scope the listing to the requested namespace. An empty Namespace lists
+	// across all of them, which stays the default for a cluster-wide selector.
+	// Without this the selector always resolved cluster-wide, so a caller asking
+	// for one namespace silently got every matching workload in the cluster.
+	summaries, err := actionHandler.ksStorageClient.SpdxV1beta1().WorkloadConfigurationScanSummaries(selector.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("operatorAction: failed to list configuration scan summaries: %w", err)
 	}
@@ -93,6 +97,13 @@ func (actionHandler *ActionHandler) resolveSelectorTargets(ctx context.Context, 
 		// The remediators only act on namespaced workload kinds; skip anything
 		// else (e.g. CronJob) rather than failing the whole batch later.
 		if !remediators.IsNamespacedKind(target.Kind) {
+			continue
+		}
+		// The target namespace comes from the summary's labels, which is what the
+		// remediator actually acts on. Check it against the requested namespace
+		// too, so a summary whose labels disagree with the object's own namespace
+		// can never escape the requested scope.
+		if selector.Namespace != "" && target.Namespace != selector.Namespace {
 			continue
 		}
 		// Protected/excluded namespaces are never remediated, even by a selector.

--- a/mainhandler/findings_test.go
+++ b/mainhandler/findings_test.go
@@ -225,3 +225,86 @@ func scanSummaryNamed(ns, kind, name, crName string, controls map[string]spdxv1b
 	s.Name = crName
 	return s
 }
+
+// multiNamespaceStore holds the same failing control in three namespaces, so a
+// scoped selector can be told apart from a cluster-wide one.
+func multiNamespaceStore() *kssfake.Clientset {
+	return kssfake.NewSimpleClientset(
+		scanSummary("payments", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+		scanSummary("billing", "Deployment", "invoices", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+		scanSummary("shipping", "Deployment", "tracker", map[string]spdxv1beta1.ScannedControlSummary{
+			"C-0016": failedControl("C-0016", "High"),
+		}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1}),
+	)
+}
+
+func TestResolveSelectorTargets_ScopedToNamespace(t *testing.T) {
+	ah := newResolver(multiNamespaceStore(), newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{
+		Control:   "C-0016",
+		Namespace: "payments",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []remediators.Target{{Kind: "Deployment", Namespace: "payments", Name: "api"}}, targets,
+		"a namespaced selector must not reach workloads in other namespaces")
+}
+
+func TestResolveSelectorTargets_EmptyNamespaceStaysClusterWide(t *testing.T) {
+	ah := newResolver(multiNamespaceStore(), newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{Control: "C-0016"})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []remediators.Target{
+		{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		{Kind: "Deployment", Namespace: "billing", Name: "invoices"},
+		{Kind: "Deployment", Namespace: "shipping", Name: "tracker"},
+	}, targets, "an unset namespace must keep the previous cluster-wide behaviour")
+}
+
+func TestResolveSelectorTargets_NamespaceScopeWithMinSeverity(t *testing.T) {
+	ah := newResolver(multiNamespaceStore(), newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{
+		MinSeverity: "High",
+		Namespace:   "billing",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []remediators.Target{{Kind: "Deployment", Namespace: "billing", Name: "invoices"}}, targets,
+		"namespace scoping must apply to a severity-only selector too")
+}
+
+func TestResolveSelectorTargets_NamespaceWithNoFindings(t *testing.T) {
+	ah := newResolver(multiNamespaceStore(), newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{
+		Control:   "C-0016",
+		Namespace: "empty-ns",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, targets, "a namespace with no matching findings resolves to nothing, and the caller reports it")
+}
+
+func TestResolveSelectorTargets_MislabelledSummaryCannotEscapeScope(t *testing.T) {
+	// A summary stored in "payments" whose labels point at a workload in
+	// "billing". Listing is scoped server-side, but the remediator acts on the
+	// label-derived namespace, so the resolver must drop it rather than let a
+	// payments-scoped request mutate a billing workload.
+	mislabelled := scanSummary("payments", "Deployment", "api", map[string]spdxv1beta1.ScannedControlSummary{
+		"C-0016": failedControl("C-0016", "High"),
+	}, spdxv1beta1.WorkloadConfigurationScanSeveritiesSummary{High: 1})
+	mislabelled.Labels[helpers.RelatedNamespaceMetadataKey] = "billing"
+
+	ah := newResolver(kssfake.NewSimpleClientset(mislabelled), newTestConfig(config.Config{Namespace: "kubescape"}))
+
+	targets, err := ah.resolveSelectorTargets(context.Background(), &apis.OperatorActionSelector{
+		Control:   "C-0016",
+		Namespace: "payments",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, targets, "a summary whose labels leave the requested namespace must not be selected")
+}


### PR DESCRIPTION
## The problem

`OperatorActionSelector.Namespace` is part of the `operatorAction` contract and is documented as limiting a findings-driven selector to a single namespace:

```go
// Namespace optionally limits the selector to a single namespace.
Namespace string `json:"namespace,omitempty"`
```

`resolveSelectorTargets` never read it. It always listed cluster-wide:

```go
summaries, err := actionHandler.ksStorageClient.SpdxV1beta1().
    WorkloadConfigurationScanSummaries("").List(ctx, metav1.ListOptions{})
```

So a request to quarantine workloads failing C-0016 in `payments` would resolve to every workload failing C-0016 anywhere in the cluster, and nothing in the response or the events would indicate the scope was wider than asked for. For an action set whose whole point is to mutate running workloads, silently ignoring the field that bounds the blast radius is the wrong failure mode.

## The fix

Two parts, because there are two different namespaces in play.

The listing is now scoped server-side to `selector.Namespace`, which is both correct and cheaper than filtering client-side. An empty `Namespace` still lists across all namespaces, so cluster-wide selectors behave exactly as before.

The resolver also drops any summary whose label-derived target namespace falls outside the requested one. That namespace comes from the `kubescape.io/workload-namespace` label and is what the remediator actually acts on, so if it ever disagreed with the namespace the summary object is stored in, the server-side scoping alone would not be enough. This is defence in depth rather than a bug I observed in practice, but the cost is one comparison and the downside of getting it wrong is mutating a workload in a namespace the caller did not name.

## Context

Part of the phased `operatorAction` remediation framework:

- Proposal: kubescape/designs-and-proposals#5
- Original issue: kubescape/kubescape#1770
- Command contract, where the Namespace field is defined: armosec/armoapi-go#655
- Findings-driven targeting, which this fixes: #391
- Related work in the operator: #383 and #388

Found while wiring the CLI side of findings-driven targeting in kubescape/kubescape#3474. That PR adds `--control` and `--min-severity`, and deliberately rejects `--target-namespace` combined with a selector precisely because of this bug, since offering the flag while the operator ignores it would be worse than not offering it at all.

Once this merges and ships in a release, the CLI guard can be lifted and `--target-namespace` passed through. The guard needs to outlive this fix by a release, because a CLI that sends `selector.namespace` to an older operator would hit exactly the silent widening described above.

## Testing

Five new tests in `mainhandler/findings_test.go`:

- a namespaced selector resolves only to workloads in that namespace
- an empty namespace still resolves cluster-wide, so existing behaviour is unchanged
- namespace scoping applies to a severity-only selector, not just a control-based one
- a namespace with no matching findings resolves to nothing, which the caller already reports as an error
- a summary whose labels point outside the requested namespace is dropped

I confirmed the three scoping tests fail against `main` without the change and pass with it, so they are genuine regression tests rather than tests written to match current behaviour. Full `mainhandler` and `mainhandler/remediators` suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Findings-based selectors now correctly respect the requested namespace.
  * Empty namespaces continue to support cluster-wide resolution.
  * Targets outside the requested namespace are excluded from summaries.
* **Tests**
  * Added coverage for namespace filtering, cluster-wide behavior, missing findings, and mismatched target labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->