### PR TITLE
feat(remediation): add generic patch action for arbitrary workload patches

### DIFF
--- a/docs/features/patch-remediation-action.md
+++ b/docs/features/patch-remediation-action.md
@@ -65,20 +65,44 @@ A confirmed (`dryRun: false`) patch's body and patch type are recorded on
 `OperatorCommand` status payload and the `KubescapeRemediation` Kubernetes
 event — so an applied change can be reconstructed after the fact.
 
-## Known gap: endpoint authorization
+## patch is only deliverable via the OperatorCommand CRD path
 
-`patch` is dispatched the same way as every other `operatorAction`, including
-via the operator's `/v1/triggerAction` HTTP endpoint
-(`restapihandler/triggeraction.go`), which currently has **no
-authentication or authorization** in front of it. That gap predates this
-action, but `patch` raises its stakes materially: previously a caller
-reaching that endpoint could only trigger hardcoded, low-blast-radius writes
-(an annotation key, a deny-all NetworkPolicy). With `patch`, the same
-unauthenticated reachability lets a caller direct the operator's cluster-wide
-patch RBAC at arbitrary (denylist-permitting) workload fields.
+Every other `operatorAction` (`annotate`, `quarantine`, `revert`, and
+`cordon` once implemented) is reachable via **two** ingress points that both
+funnel into the same `handleRequest`/`handleOperatorAction` dispatch:
 
-**Authenticating and authorizing `/v1/triggerAction`** (e.g. via
-`TokenReview` + `SubjectAccessReview` per caller) should be treated as a
-prerequisite before enabling this action in any environment where that
-endpoint is reachable by untrusted callers. This is tracked as a follow-up,
-not addressed by this change.
+1. The `OperatorCommand` CRD, watched by `watcher/commandshandler.go`. In the
+   commercial/connected deployment this is written by the `synchronizer`
+   component, whose own K8s ServiceAccount and `ClusterRole` are the actual
+   authorization boundary — reachable only through synchronizer's own
+   authenticated connection to the backend. In the standalone/GitOps case a
+   user or CI pipeline `kubectl apply`s the CR directly, authorized by their
+   own RBAC on that resource.
+2. The `/v1/triggerAction` HTTP endpoint (`restapihandler/triggeraction.go`).
+   This is the **documented, intended transport** for the `kubescape` CLI's
+   `operator remediate annotate|quarantine|revert` subcommand (see
+   [`designs-and-proposals/cli-cluster-operations.md`](https://github.com/kubescape/designs-and-proposals/blob/main/proposals/cli-cluster-operations.md)),
+   which reaches it via `kubectl port-forward` — itself RBAC-gated (`pods/portforward`
+   create permission on the operator's namespace). However, the endpoint
+   itself has **no application-level caller authentication**, and its
+   `Service` carries no `NetworkPolicy`: any pod on the cluster network can
+   reach `operator:4002/v1/triggerAction` directly, bypassing the
+   port-forward/RBAC boundary the CLI relies on entirely (verified live —
+   see [operator#411](https://github.com/kubescape/operator/pull/411),
+   closed in favor of this narrower fix once it was clear the endpoint's
+   `operatorAction` dispatch is itself a required, documented feature, not
+   an oversight).
+
+`patch` was **not** part of that design (the design's action set is
+`annotate`/`quarantine`/`cordon`/`revert`) and has no CLI subcommand or other
+legitimate use of the `/v1/triggerAction` transport. So rather than closing
+the endpoint's general reachability gap (a NetworkPolicy-level fix, tracked
+separately against `kubescape/helm-charts`, since `kubectl port-forward`
+traffic never crosses the pod network a `NetworkPolicy` governs and so isn't
+blocked by one), `handleOperatorAction` rejects `patch` outright unless
+`sessionObj.ParentCommandDetails` is set — the signal, already used
+elsewhere in this codebase, that a command was delivered via the CRD watcher
+rather than `/v1/triggerAction`. This keeps every design-documented action
+working exactly as before while giving `patch` — the one action with no
+legitimate use for the unauthenticated HTTP path — the RBAC-backed CRD path
+as its only way in.

--- a/docs/features/patch-remediation-action.md
+++ b/docs/features/patch-remediation-action.md
@@ -24,10 +24,11 @@ registered in `remediators.NewRegistry`.
 - `dryRun` — same safe-by-default semantics as every other action: omitted or
   `true` means a server-side dry-run; only an explicit `false` writes.
 
-`patch`/`patchType` are not yet part of armoapi-go's typed
-`OperatorActionArgs` schema, so they are read directly off the raw
-`Command.Args` map (see `extractPatchArgs` in `actionhandler.go`) rather than
-the parsed struct used for the other fields.
+`patch`/`patchType` are typed fields on `apis.OperatorActionArgs` as of
+armoapi-go `v0.0.761` (`Patch apis.OperatorActionPatchBody`, `PatchType
+string`). `OperatorActionPatchBody.UnmarshalJSON` accepts either a JSON
+string or a raw JSON object on the wire, matching what this action has
+always tolerated.
 
 ## Safety rails
 

--- a/docs/features/patch-remediation-action.md
+++ b/docs/features/patch-remediation-action.md
@@ -1,0 +1,84 @@
+# Generic patch remediation action
+
+## Overview
+
+`TypeOperatorAction` ("operatorAction") gained a `patch` action alongside
+`annotate`, `quarantine`, and `revert`. It lets the backend apply a targeted
+Strategic Merge Patch or JSON Merge Patch (e.g. injecting
+`securityContext.seccompProfile`) to a workload without knowing — or sending —
+the workload's full YAML.
+
+Implementation: `mainhandler/remediators/patch.go` (`PatchRemediator`),
+dispatched from `mainhandler/actionhandler.go`'s `handleActionOnTarget`, and
+registered in `remediators.NewRegistry`.
+
+## Command shape
+
+`Command.Args` for `action: "patch"`:
+
+- `target` — as for every other action (`kind`, `namespace`, `name`); one of
+  `Deployment`, `StatefulSet`, `DaemonSet`, `Pod`.
+- `patch` (required) — a JSON or YAML object, as a string or a raw JSON value.
+  Must be object-shaped: RFC 6902 JSON Patch arrays are not supported.
+- `patchType` (optional) — `"strategic"` (default) or `"merge"`.
+- `dryRun` — same safe-by-default semantics as every other action: omitted or
+  `true` means a server-side dry-run; only an explicit `false` writes.
+
+`patch`/`patchType` are not yet part of armoapi-go's typed
+`OperatorActionArgs` schema, so they are read directly off the raw
+`Command.Args` map (see `extractPatchArgs` in `actionhandler.go`) rather than
+the parsed struct used for the other fields.
+
+## Safety rails
+
+Same generic rails as every action, enforced in `handleActionOnTarget` before
+dispatch: dry-run-by-default, the target namespace must not be in
+`SkipNamespace`, and a namespaced kind requires a namespace.
+
+Patch-specific hardening, enforced in both `Plan` and `Apply` (so a
+hand-constructed `Plan` cannot skip it):
+
+- **Size cap** — patch body limited to 256 KiB.
+- **Shape validation** — must decode to a non-empty JSON/YAML object; `null`,
+  empty objects (`{}`), and JSON Patch arrays are rejected.
+- **Escalation denylist** — a patch may not touch: `hostNetwork`, `hostPID`,
+  `hostIPC`, `serviceAccountName`/`serviceAccount`, `volumes`, `nodeName`,
+  `metadata.ownerReferences`, `metadata.finalizers`, a container's
+  `securityContext.privileged`/`allowPrivilegeEscalation`/
+  `capabilities.add`, or a container's `image`. This is defense-in-depth
+  against a patch escalating from "fix a workload's config" to node or
+  cluster compromise.
+
+## Revert
+
+Arbitrary patches carry no recorded pre-state, so `PatchRemediator.Revert`
+always returns an error and is deliberately **not** included in
+`revertTarget`'s `reversible` list (including it would abort revert for every
+target, not just patched ones). When a `revert` action runs against a target
+that may have been patched, the recorded result/audit event explicitly notes
+that any prior patch was **not** reverted.
+
+## Audit trail
+
+A confirmed (`dryRun: false`) patch's body and patch type are recorded on
+`remediators.Result` (`Patch`/`PatchType` fields), which flows into both the
+`OperatorCommand` status payload and the `KubescapeRemediation` Kubernetes
+event — so an applied change can be reconstructed after the fact.
+
+## Known gap: endpoint authorization
+
+`patch` is dispatched the same way as every other `operatorAction`, including
+via the operator's `/v1/triggerAction` HTTP endpoint
+(`restapihandler/triggeraction.go`), which currently has **no
+authentication or authorization** in front of it. That gap predates this
+action, but `patch` raises its stakes materially: previously a caller
+reaching that endpoint could only trigger hardcoded, low-blast-radius writes
+(an annotation key, a deny-all NetworkPolicy). With `patch`, the same
+unauthenticated reachability lets a caller direct the operator's cluster-wide
+patch RBAC at arbitrary (denylist-permitting) workload fields.
+
+**Authenticating and authorizing `/v1/triggerAction`** (e.g. via
+`TokenReview` + `SubjectAccessReview` per caller) should be treated as a
+prerequisite before enabling this action in any environment where that
+endpoint is reachable by untrusted callers. This is tracked as a follow-up,
+not addressed by this change.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kubescape/operator
 go 1.25.8
 
 require (
-	github.com/armosec/armoapi-go v0.0.720
+	github.com/armosec/armoapi-go v0.0.761
 	github.com/armosec/registryx v0.0.35
 	github.com/armosec/utils-go v0.0.58
 	github.com/armosec/utils-k8s-go v0.0.35

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armosec/armoapi-go v0.0.720 h1:mtxUw2wWPRSQWcUf89Eoc9J81SBIC0YaK66XqAXuhCQ=
 github.com/armosec/armoapi-go v0.0.720/go.mod h1:9jAH0g8ZsryhiBDd/aNMX4+n10bGwTx/doWCyyjSxts=
+github.com/armosec/armoapi-go v0.0.761 h1:/idEh/lGFLGUIF64/ecuusCYHPzs7F6T/VQ9zFHEaxA=
+github.com/armosec/armoapi-go v0.0.761/go.mod h1:1l+70fBK09F7zI2jArrPUWVHaLkijg+sQutFTmE6HRs=
 github.com/armosec/gojay v1.2.17 h1:VSkLBQzD1c2V+FMtlGFKqWXNsdNvIKygTKJI9ysY8eM=
 github.com/armosec/gojay v1.2.17/go.mod h1:vuvX3DlY0nbVrJ0qCklSS733AWMoQboq3cFyuQW9ybc=
 github.com/armosec/registryx v0.0.35 h1:fvP5/IZL0+jJUnNXvAj6ohJ6UVHaASVpR/cPLX0I4f0=

--- a/mainhandler/actionhandler.go
+++ b/mainhandler/actionhandler.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // handleOperatorAction handles a TypeOperatorAction command. It parses the typed
@@ -47,6 +48,18 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 		return fmt.Errorf("operatorAction: ttl/auto-revert is not supported yet (later phase); omit ttl")
 	}
 
+	// 'patch' and 'patchType' are not part of armoapi-go's typed OperatorActionArgs
+	// yet (see extractPatchArgs), so they're parsed once here — target-independent
+	// — rather than once per resolved target.
+	var patch string
+	var patchType types.PatchType
+	if args.Action == remediators.OperatorActionPatch {
+		patch, patchType, err = extractPatchArgs(cmd.Args)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Resolve the target set: an explicit Target, or a findings-driven Selector
 	// that reads the stored configuration-scan summaries (no re-scan). Exactly
 	// one of the two must be provided.
@@ -62,11 +75,11 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 	// error verbatim. A multi-target selector runs every target and aggregates
 	// failures so one bad workload does not abandon the rest.
 	if len(targets) == 1 {
-		return actionHandler.handleActionOnTarget(ctx, args, targets[0], registry, dryRun)
+		return actionHandler.handleActionOnTarget(ctx, args, targets[0], registry, dryRun, patch, patchType)
 	}
 	var errs []error
 	for _, target := range targets {
-		if err := actionHandler.handleActionOnTarget(ctx, args, target, registry, dryRun); err != nil {
+		if err := actionHandler.handleActionOnTarget(ctx, args, target, registry, dryRun, patch, patchType); err != nil {
 			errs = append(errs, fmt.Errorf("target %s: %w", target, err))
 		}
 	}
@@ -99,8 +112,11 @@ func (actionHandler *ActionHandler) resolveTargets(ctx context.Context, args api
 }
 
 // handleActionOnTarget enforces the per-target safety rails and dispatches the
-// action to the matching remediator. It runs once per resolved target.
-func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, args apis.OperatorActionArgs, target remediators.Target, registry map[apis.OperatorActionType]remediators.Remediator, dryRun bool) error {
+// action to the matching remediator. It runs once per resolved target. patch
+// and patchType are the patch action's payload, parsed once in
+// handleOperatorAction (see extractPatchArgs) since they are target-independent;
+// they are unused for every other action.
+func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, args apis.OperatorActionArgs, target remediators.Target, registry map[apis.OperatorActionType]remediators.Remediator, dryRun bool, patch string, patchType types.PatchType) error {
 	// All current target kinds are namespaced. Require the namespace up front so
 	// the excluded-namespace rail below is actually enforced, instead of an empty
 	// namespace slipping past it and failing late at the API server.
@@ -123,6 +139,10 @@ func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, ar
 		req := remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef}
 		return actionHandler.applyRemediation(ctx, registry[args.Action], req, dryRun)
 
+	case remediators.OperatorActionPatch:
+		req := remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef, Patch: patch, PatchType: patchType}
+		return actionHandler.applyRemediation(ctx, registry[args.Action], req, dryRun)
+
 	case apis.OperatorActionRevert:
 		// Pass dryRun so a default (no --confirm) revert previews instead of writing.
 		return actionHandler.revertTarget(ctx, registry, target, dryRun)
@@ -133,6 +153,49 @@ func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, ar
 	default:
 		return fmt.Errorf("operatorAction: unknown action %q", args.Action)
 	}
+}
+
+// extractPatchArgs pulls the generic patch payload out of the raw Command.Args
+// map. 'patch' and 'patchType' are not (yet) part of armoapi-go's typed
+// OperatorActionArgs schema, so — unlike the other action fields — they are
+// read directly from the map rather than off the parsed apis.OperatorActionArgs:
+//   - "patch" (required) may be a JSON/YAML string or a raw JSON object.
+//   - "patchType" (optional) is "strategic" (default) or "merge".
+func extractPatchArgs(rawArgs map[string]any) (string, types.PatchType, error) {
+	v, ok := rawArgs["patch"]
+	if !ok || v == nil {
+		return "", "", fmt.Errorf("operatorAction: patch action requires a 'patch' payload")
+	}
+
+	var patch string
+	switch p := v.(type) {
+	case string:
+		patch = p
+	default:
+		b, err := json.Marshal(p)
+		if err != nil {
+			return "", "", fmt.Errorf("operatorAction: failed to encode 'patch' payload: %w", err)
+		}
+		patch = string(b)
+	}
+
+	patchType := types.StrategicMergePatchType
+	if raw, ok := rawArgs["patchType"]; ok && raw != nil {
+		pt, ok := raw.(string)
+		if !ok {
+			return "", "", fmt.Errorf("operatorAction: 'patchType' must be a string")
+		}
+		switch pt {
+		case remediators.PatchTypeStrategic:
+			patchType = types.StrategicMergePatchType
+		case remediators.PatchTypeMerge:
+			patchType = types.MergePatchType
+		default:
+			return "", "", fmt.Errorf("operatorAction: unsupported patchType %q (supported: %s, %s)", pt, remediators.PatchTypeStrategic, remediators.PatchTypeMerge)
+		}
+	}
+
+	return patch, patchType, nil
 }
 
 // applyRemediation runs a remediator's Plan -> Apply and records the result.
@@ -154,9 +217,20 @@ func (actionHandler *ActionHandler) applyRemediation(ctx context.Context, r reme
 // object that no longer exists (NotFound) is skipped, not treated as an error,
 // so a leftover artifact (e.g. a NetworkPolicy whose workload was deleted) is
 // still cleaned up.
+//
+// remediators.OperatorActionPatch is deliberately absent from reversible:
+// PatchRemediator.Revert always returns an error (arbitrary patches carry no
+// recorded prior state), and this loop treats any non-NotFound error as fatal
+// — including it here would abort revert for every target, even ones only
+// annotated or quarantined. Because a patch is silently left unreverted, the
+// caveat below is appended to the recorded result so the audit trail does not
+// claim more than actually happened.
 func (actionHandler *ActionHandler) revertTarget(ctx context.Context, registry map[apis.OperatorActionType]remediators.Remediator, target remediators.Target, dryRun bool) error {
 	reversible := []apis.OperatorActionType{apis.OperatorActionAnnotate, apis.OperatorActionQuarantine}
 	var descriptions []string
+	if _, ok := registry[remediators.OperatorActionPatch]; ok {
+		descriptions = append(descriptions, "any generic patch previously applied to this target was NOT reverted (no prior state is recorded)")
+	}
 	applied := false
 	for _, action := range reversible {
 		r, ok := registry[action]

--- a/mainhandler/actionhandler.go
+++ b/mainhandler/actionhandler.go
@@ -54,6 +54,17 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 	var patch string
 	var patchType types.PatchType
 	if args.Action == remediators.OperatorActionPatch {
+		// Unlike annotate/quarantine/revert (and cordon, once implemented), patch
+		// was never part of the CLI-cluster-operations design and has no
+		// legitimate /v1/triggerAction delivery path (that HTTP endpoint has no
+		// caller auth beyond "reached it somehow" — see kubescape/operator#411).
+		// ParentCommandDetails is set only by the OperatorCommand CRD watcher
+		// (watcher/commandshandler.go), which is reachable solely through the
+		// RBAC-gated synchronizer/CRD-apply channel, so its absence here means
+		// this command arrived over triggerAction instead.
+		if actionHandler.sessionObj.ParentCommandDetails == nil {
+			return fmt.Errorf("operatorAction: patch is only supported via the OperatorCommand CRD delivery path, not triggerAction")
+		}
 		patch, patchType, err = extractPatchArgs(cmd.Args)
 		if err != nil {
 			return err

--- a/mainhandler/actionhandler.go
+++ b/mainhandler/actionhandler.go
@@ -48,27 +48,16 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 		return fmt.Errorf("operatorAction: ttl/auto-revert is not supported yet (later phase); omit ttl")
 	}
 
-	// 'patch' and 'patchType' are not part of armoapi-go's typed OperatorActionArgs
-	// yet (see extractPatchArgs), so they're parsed once here — target-independent
-	// — rather than once per resolved target.
-	var patch string
-	var patchType types.PatchType
-	if args.Action == remediators.OperatorActionPatch {
-		// Unlike annotate/quarantine/revert (and cordon, once implemented), patch
-		// was never part of the CLI-cluster-operations design and has no
-		// legitimate /v1/triggerAction delivery path (that HTTP endpoint has no
-		// caller auth beyond "reached it somehow" — see kubescape/operator#411).
-		// ParentCommandDetails is set only by the OperatorCommand CRD watcher
-		// (watcher/commandshandler.go), which is reachable solely through the
-		// RBAC-gated synchronizer/CRD-apply channel, so its absence here means
-		// this command arrived over triggerAction instead.
-		if actionHandler.sessionObj.ParentCommandDetails == nil {
-			return fmt.Errorf("operatorAction: patch is only supported via the OperatorCommand CRD delivery path, not triggerAction")
-		}
-		patch, patchType, err = extractPatchArgs(cmd.Args)
-		if err != nil {
-			return err
-		}
+	// Unlike annotate/quarantine/revert (and cordon, once implemented), patch
+	// was never part of the CLI-cluster-operations design and has no
+	// legitimate /v1/triggerAction delivery path (that HTTP endpoint has no
+	// caller auth beyond "reached it somehow" — see kubescape/operator#411).
+	// ParentCommandDetails is set only by the OperatorCommand CRD watcher
+	// (watcher/commandshandler.go), which is reachable solely through the
+	// RBAC-gated synchronizer/CRD-apply channel, so its absence here means
+	// this command arrived over triggerAction instead.
+	if args.Action == apis.OperatorActionPatch && actionHandler.sessionObj.ParentCommandDetails == nil {
+		return fmt.Errorf("operatorAction: patch is only supported via the OperatorCommand CRD delivery path, not triggerAction")
 	}
 
 	// Resolve the target set: an explicit Target, or a findings-driven Selector
@@ -86,11 +75,11 @@ func (actionHandler *ActionHandler) handleOperatorAction(ctx context.Context) er
 	// error verbatim. A multi-target selector runs every target and aggregates
 	// failures so one bad workload does not abandon the rest.
 	if len(targets) == 1 {
-		return actionHandler.handleActionOnTarget(ctx, args, targets[0], registry, dryRun, patch, patchType)
+		return actionHandler.handleActionOnTarget(ctx, args, targets[0], registry, dryRun)
 	}
 	var errs []error
 	for _, target := range targets {
-		if err := actionHandler.handleActionOnTarget(ctx, args, target, registry, dryRun, patch, patchType); err != nil {
+		if err := actionHandler.handleActionOnTarget(ctx, args, target, registry, dryRun); err != nil {
 			errs = append(errs, fmt.Errorf("target %s: %w", target, err))
 		}
 	}
@@ -123,11 +112,8 @@ func (actionHandler *ActionHandler) resolveTargets(ctx context.Context, args api
 }
 
 // handleActionOnTarget enforces the per-target safety rails and dispatches the
-// action to the matching remediator. It runs once per resolved target. patch
-// and patchType are the patch action's payload, parsed once in
-// handleOperatorAction (see extractPatchArgs) since they are target-independent;
-// they are unused for every other action.
-func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, args apis.OperatorActionArgs, target remediators.Target, registry map[apis.OperatorActionType]remediators.Remediator, dryRun bool, patch string, patchType types.PatchType) error {
+// action to the matching remediator. It runs once per resolved target.
+func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, args apis.OperatorActionArgs, target remediators.Target, registry map[apis.OperatorActionType]remediators.Remediator, dryRun bool) error {
 	// All current target kinds are namespaced. Require the namespace up front so
 	// the excluded-namespace rail below is actually enforced, instead of an empty
 	// namespace slipping past it and failing late at the API server.
@@ -150,8 +136,15 @@ func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, ar
 		req := remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef}
 		return actionHandler.applyRemediation(ctx, registry[args.Action], req, dryRun)
 
-	case remediators.OperatorActionPatch:
-		req := remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef, Patch: patch, PatchType: patchType}
+	case apis.OperatorActionPatch:
+		if args.Patch == "" {
+			return fmt.Errorf("operatorAction: patch action requires a 'patch' payload")
+		}
+		patchType, err := patchTypeFromArgs(args.PatchType)
+		if err != nil {
+			return err
+		}
+		req := remediators.Request{Target: target, Reason: args.Reason, FindingRef: args.FindingRef, Patch: string(args.Patch), PatchType: patchType}
 		return actionHandler.applyRemediation(ctx, registry[args.Action], req, dryRun)
 
 	case apis.OperatorActionRevert:
@@ -166,47 +159,18 @@ func (actionHandler *ActionHandler) handleActionOnTarget(ctx context.Context, ar
 	}
 }
 
-// extractPatchArgs pulls the generic patch payload out of the raw Command.Args
-// map. 'patch' and 'patchType' are not (yet) part of armoapi-go's typed
-// OperatorActionArgs schema, so — unlike the other action fields — they are
-// read directly from the map rather than off the parsed apis.OperatorActionArgs:
-//   - "patch" (required) may be a JSON/YAML string or a raw JSON object.
-//   - "patchType" (optional) is "strategic" (default) or "merge".
-func extractPatchArgs(rawArgs map[string]any) (string, types.PatchType, error) {
-	v, ok := rawArgs["patch"]
-	if !ok || v == nil {
-		return "", "", fmt.Errorf("operatorAction: patch action requires a 'patch' payload")
-	}
-
-	var patch string
-	switch p := v.(type) {
-	case string:
-		patch = p
+// patchTypeFromArgs maps the wire vocabulary used in OperatorActionArgs.PatchType
+// ("strategic"/"merge") to the k8s.io/apimachinery patch media type, defaulting
+// to Strategic Merge Patch when empty.
+func patchTypeFromArgs(patchType string) (types.PatchType, error) {
+	switch patchType {
+	case "", remediators.PatchTypeStrategic:
+		return types.StrategicMergePatchType, nil
+	case remediators.PatchTypeMerge:
+		return types.MergePatchType, nil
 	default:
-		b, err := json.Marshal(p)
-		if err != nil {
-			return "", "", fmt.Errorf("operatorAction: failed to encode 'patch' payload: %w", err)
-		}
-		patch = string(b)
+		return "", fmt.Errorf("operatorAction: unsupported patchType %q (supported: %s, %s)", patchType, remediators.PatchTypeStrategic, remediators.PatchTypeMerge)
 	}
-
-	patchType := types.StrategicMergePatchType
-	if raw, ok := rawArgs["patchType"]; ok && raw != nil {
-		pt, ok := raw.(string)
-		if !ok {
-			return "", "", fmt.Errorf("operatorAction: 'patchType' must be a string")
-		}
-		switch pt {
-		case remediators.PatchTypeStrategic:
-			patchType = types.StrategicMergePatchType
-		case remediators.PatchTypeMerge:
-			patchType = types.MergePatchType
-		default:
-			return "", "", fmt.Errorf("operatorAction: unsupported patchType %q (supported: %s, %s)", pt, remediators.PatchTypeStrategic, remediators.PatchTypeMerge)
-		}
-	}
-
-	return patch, patchType, nil
 }
 
 // applyRemediation runs a remediator's Plan -> Apply and records the result.
@@ -229,7 +193,7 @@ func (actionHandler *ActionHandler) applyRemediation(ctx context.Context, r reme
 // so a leftover artifact (e.g. a NetworkPolicy whose workload was deleted) is
 // still cleaned up.
 //
-// remediators.OperatorActionPatch is deliberately absent from reversible:
+// apis.OperatorActionPatch is deliberately absent from reversible:
 // PatchRemediator.Revert always returns an error (arbitrary patches carry no
 // recorded prior state), and this loop treats any non-NotFound error as fatal
 // — including it here would abort revert for every target, even ones only
@@ -239,7 +203,7 @@ func (actionHandler *ActionHandler) applyRemediation(ctx context.Context, r reme
 func (actionHandler *ActionHandler) revertTarget(ctx context.Context, registry map[apis.OperatorActionType]remediators.Remediator, target remediators.Target, dryRun bool) error {
 	reversible := []apis.OperatorActionType{apis.OperatorActionAnnotate, apis.OperatorActionQuarantine}
 	var descriptions []string
-	if _, ok := registry[remediators.OperatorActionPatch]; ok {
+	if _, ok := registry[apis.OperatorActionPatch]; ok {
 		descriptions = append(descriptions, "any generic patch previously applied to this target was NOT reverted (no prior state is recorded)")
 	}
 	applied := false

--- a/mainhandler/actionhandler_test.go
+++ b/mainhandler/actionhandler_test.go
@@ -58,9 +58,10 @@ func newActionHandlerForTestWithStorage(t *testing.T, client kubernetes.Interfac
 }
 
 // newActionHandlerForTestWithExtraArgs builds an ActionHandler whose
-// Command.Args merges args (the typed schema) with extra raw keys — needed for
-// fields like "patch"/"patchType" that are not (yet) part of armoapi-go's typed
-// OperatorActionArgs and are read directly off the raw map (see extractPatchArgs).
+// Command.Args merges args (the typed schema) with extra raw keys — for
+// exercising fields not (yet) part of armoapi-go's typed OperatorActionArgs.
+// Patch/PatchType no longer need this (they're typed fields as of
+// armoapi-go v0.0.761); extra is nil at every current call site.
 func newActionHandlerForTestWithExtraArgs(t *testing.T, client kubernetes.Interface, storageClient kssc.Interface, cfg config.IConfig, args apis.OperatorActionArgs, extra map[string]any) *ActionHandler {
 	t.Helper()
 	argsMap, err := args.ToArgs()
@@ -439,12 +440,11 @@ func TestHandleOperatorAction_PatchDefaultsToDryRun(t *testing.T) {
 	capturePatchDryRun(client, "deployments", &dryRun)
 
 	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
+		Action: apis.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"seccomp":"applied"}}}`,
 		// DryRun intentionally nil
-	}, map[string]any{
-		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
-	})
+	}, nil)
 
 	require.NoError(t, ah.handleOperatorAction(context.Background()))
 	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a patch action without dryRun must default to server-side dry-run")
@@ -458,12 +458,11 @@ func TestHandleOperatorAction_PatchConfirmWritesStrategicMergePatch(t *testing.T
 	capturePatchType(client, "deployments", &patchType)
 
 	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
+		Action: apis.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"seccomp":"applied"}}}`,
 		DryRun: boolPtr(false),
-	}, map[string]any{
-		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
-	})
+	}, nil)
 
 	require.NoError(t, ah.handleOperatorAction(context.Background()))
 	assert.Equal(t, types.StrategicMergePatchType, patchType, "omitting patchType must default to Strategic Merge Patch")
@@ -481,13 +480,12 @@ func TestHandleOperatorAction_PatchConfirmWritesJSONMergePatch(t *testing.T) {
 	capturePatchType(client, "deployments", &patchType)
 
 	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
-		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
-		DryRun: boolPtr(false),
-	}, map[string]any{
-		"patch":     `{"metadata":{"labels":{"seccomp":"applied"}}}`,
-		"patchType": "merge",
-	})
+		Action:    apis.OperatorActionPatch,
+		Target:    &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:     `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+		PatchType: "merge",
+		DryRun:    boolPtr(false),
+	}, nil)
 
 	require.NoError(t, ah.handleOperatorAction(context.Background()))
 	assert.Equal(t, types.MergePatchType, patchType, "patchType=merge must send a JSON Merge Patch, not the default Strategic Merge Patch")
@@ -504,12 +502,11 @@ func TestHandleOperatorAction_PatchExcludedNamespace(t *testing.T) {
 	cfg := newTestConfig(config.Config{Namespace: "kubescape", ExcludeNamespaces: []string{"kube-system"}})
 
 	ah := newActionHandlerForCRDOriginTest(t, client, cfg, apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
+		Action: apis.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "kube-system", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"seccomp":"applied"}}}`,
 		DryRun: boolPtr(false),
-	}, map[string]any{
-		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
-	})
+	}, nil)
 
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
@@ -522,7 +519,7 @@ func TestHandleOperatorAction_PatchMissingPayload(t *testing.T) {
 	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
 
 	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
+		Action: apis.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		DryRun: boolPtr(false),
 	}, nil)
@@ -538,12 +535,11 @@ func TestHandleOperatorAction_PatchInvalidPayload(t *testing.T) {
 	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
 
 	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
+		Action: apis.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{not valid: [`,
 		DryRun: boolPtr(false),
-	}, map[string]any{
-		"patch": `{not valid: [`,
-	})
+	}, nil)
 
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
@@ -555,13 +551,12 @@ func TestHandleOperatorAction_PatchUnsupportedPatchType(t *testing.T) {
 	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
 
 	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
-		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
-		DryRun: boolPtr(false),
-	}, map[string]any{
-		"patch":     `{"metadata":{"labels":{"seccomp":"applied"}}}`,
-		"patchType": "json-patch",
-	})
+		Action:    apis.OperatorActionPatch,
+		Target:    &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:     `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+		PatchType: "json-patch",
+		DryRun:    boolPtr(false),
+	}, nil)
 
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
@@ -580,12 +575,11 @@ func TestHandleOperatorAction_PatchRejectedWithoutCRDOrigin(t *testing.T) {
 	capturePatchDryRun(client, "deployments", &dryRun)
 
 	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
-		Action: remediators.OperatorActionPatch,
+		Action: apis.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"seccomp":"applied"}}}`,
 		DryRun: boolPtr(false),
-	}, map[string]any{
-		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
-	})
+	}, nil)
 
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)

--- a/mainhandler/actionhandler_test.go
+++ b/mainhandler/actionhandler_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"maps"
 	"testing"
+	"time"
 
 	"github.com/armosec/armoapi-go/apis"
 	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
+	"github.com/kubescape/backend/pkg/command/types/v1alpha1"
 	beUtils "github.com/kubescape/backend/pkg/utils"
+	"github.com/kubescape/k8s-interface/k8sinterface"
 	"github.com/kubescape/operator/config"
 	"github.com/kubescape/operator/mainhandler/remediators"
 	"github.com/kubescape/operator/utils"
@@ -21,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -70,6 +74,25 @@ func newActionHandlerForTestWithExtraArgs(t *testing.T, client kubernetes.Interf
 			Command: &apis.Command{CommandName: apis.TypeOperatorAction, Args: argsMap},
 		},
 	}
+}
+
+// newActionHandlerForCRDOriginTest builds an ActionHandler whose sessionObj
+// carries ParentCommandDetails — i.e. simulates a command delivered via the
+// OperatorCommand CRD watcher (watcher/commandshandler.go), the only path
+// patch is allowed to arrive on. Without this, sessionObj.ParentCommandDetails
+// is nil, simulating a command that arrived via /v1/triggerAction instead.
+func newActionHandlerForCRDOriginTest(t *testing.T, client kubernetes.Interface, cfg config.IConfig, args apis.OperatorActionArgs, extra map[string]any) *ActionHandler {
+	t.Helper()
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), cfg, args, extra)
+	ah.sessionObj.SetOperatorCommandDetails(&utils.OperatorCommandDetails{
+		Command:   &v1alpha1.OperatorCommand{ObjectMeta: metav1.ObjectMeta{Namespace: "kubescape", Name: "test-command"}},
+		StartedAt: time.Now(),
+		Client: &k8sinterface.KubernetesApi{
+			KubernetesClient: client,
+			DynamicClient:    dynamicfake.NewSimpleDynamicClient(runtime.NewScheme()),
+		},
+	})
+	return ah
 }
 
 func capturePatchDryRun(client *k8sfake.Clientset, resource string, out *[]string) {
@@ -415,7 +438,7 @@ func TestHandleOperatorAction_PatchDefaultsToDryRun(t *testing.T) {
 	var dryRun []string
 	capturePatchDryRun(client, "deployments", &dryRun)
 
-	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		// DryRun intentionally nil
@@ -434,7 +457,7 @@ func TestHandleOperatorAction_PatchConfirmWritesStrategicMergePatch(t *testing.T
 	var patchType types.PatchType
 	capturePatchType(client, "deployments", &patchType)
 
-	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		DryRun: boolPtr(false),
@@ -457,7 +480,7 @@ func TestHandleOperatorAction_PatchConfirmWritesJSONMergePatch(t *testing.T) {
 	var patchType types.PatchType
 	capturePatchType(client, "deployments", &patchType)
 
-	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		DryRun: boolPtr(false),
@@ -480,7 +503,7 @@ func TestHandleOperatorAction_PatchExcludedNamespace(t *testing.T) {
 	client := k8sfake.NewClientset()
 	cfg := newTestConfig(config.Config{Namespace: "kubescape", ExcludeNamespaces: []string{"kube-system"}})
 
-	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), cfg, apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, cfg, apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "kube-system", Name: "api"},
 		DryRun: boolPtr(false),
@@ -498,11 +521,11 @@ func TestHandleOperatorAction_PatchExcludedNamespace(t *testing.T) {
 func TestHandleOperatorAction_PatchMissingPayload(t *testing.T) {
 	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
 
-	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		DryRun: boolPtr(false),
-	})
+	}, nil)
 
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
@@ -514,7 +537,7 @@ func TestHandleOperatorAction_PatchMissingPayload(t *testing.T) {
 func TestHandleOperatorAction_PatchInvalidPayload(t *testing.T) {
 	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
 
-	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		DryRun: boolPtr(false),
@@ -531,7 +554,7 @@ func TestHandleOperatorAction_PatchInvalidPayload(t *testing.T) {
 func TestHandleOperatorAction_PatchUnsupportedPatchType(t *testing.T) {
 	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
 
-	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+	ah := newActionHandlerForCRDOriginTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
 		Action: remediators.OperatorActionPatch,
 		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		DryRun: boolPtr(false),
@@ -543,4 +566,53 @@ func TestHandleOperatorAction_PatchUnsupportedPatchType(t *testing.T) {
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported patchType")
+}
+
+// The core regression test for this gate: a patch action that arrives without
+// ParentCommandDetails set — i.e. delivered via /v1/triggerAction rather than
+// the RBAC-gated OperatorCommand CRD watcher — must be rejected before any
+// payload parsing or cluster write, unlike annotate/quarantine/revert which
+// are legitimately deliverable via triggerAction (the CLI's `operator
+// remediate` subcommand's only transport).
+func TestHandleOperatorAction_PatchRejectedWithoutCRDOrigin(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	var dryRun []string
+	capturePatchDryRun(client, "deployments", &dryRun)
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	}, map[string]any{
+		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+	})
+
+	err := ah.handleOperatorAction(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OperatorCommand CRD delivery path")
+	assert.Empty(t, dryRun, "a rejected patch must never reach the client, dry-run or not")
+
+	got, getErr := client.AppsV1().Deployments("payments").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, getErr)
+	assert.NotContains(t, got.Labels, "seccomp", "a rejected patch must not touch the target at all")
+}
+
+// annotate/quarantine/revert must remain reachable without CRD origin: they
+// are the CLI's `operator remediate` subcommand's only transport
+// (/v1/triggerAction over kubectl port-forward), and this gate is specific to
+// patch, not a blanket requirement on every operatorAction.
+func TestHandleOperatorAction_AnnotateAllowedWithoutCRDOrigin(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+
+	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: apis.OperatorActionAnnotate,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Reason: "C-0016",
+		DryRun: boolPtr(false),
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	got, err := client.AppsV1().Deployments("payments").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "true", got.Annotations[remediators.AnnotationRemediated])
 }

--- a/mainhandler/actionhandler_test.go
+++ b/mainhandler/actionhandler_test.go
@@ -2,6 +2,7 @@ package mainhandler
 
 import (
 	"context"
+	"maps"
 	"testing"
 
 	"github.com/armosec/armoapi-go/apis"
@@ -19,6 +20,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -48,8 +50,18 @@ func newActionHandlerForTest(t *testing.T, client kubernetes.Interface, cfg conf
 
 func newActionHandlerForTestWithStorage(t *testing.T, client kubernetes.Interface, storageClient kssc.Interface, cfg config.IConfig, args apis.OperatorActionArgs) *ActionHandler {
 	t.Helper()
+	return newActionHandlerForTestWithExtraArgs(t, client, storageClient, cfg, args, nil)
+}
+
+// newActionHandlerForTestWithExtraArgs builds an ActionHandler whose
+// Command.Args merges args (the typed schema) with extra raw keys — needed for
+// fields like "patch"/"patchType" that are not (yet) part of armoapi-go's typed
+// OperatorActionArgs and are read directly off the raw map (see extractPatchArgs).
+func newActionHandlerForTestWithExtraArgs(t *testing.T, client kubernetes.Interface, storageClient kssc.Interface, cfg config.IConfig, args apis.OperatorActionArgs, extra map[string]any) *ActionHandler {
+	t.Helper()
 	argsMap, err := args.ToArgs()
 	require.NoError(t, err)
+	maps.Copy(argsMap, extra)
 	return &ActionHandler{
 		k8sAPI:          utils.NewK8sInterfaceFake(client),
 		ksStorageClient: storageClient,
@@ -63,6 +75,17 @@ func newActionHandlerForTestWithStorage(t *testing.T, client kubernetes.Interfac
 func capturePatchDryRun(client *k8sfake.Clientset, resource string, out *[]string) {
 	client.PrependReactor("patch", resource, func(action clienttesting.Action) (bool, runtime.Object, error) {
 		*out = action.(clienttesting.PatchActionImpl).PatchOptions.DryRun
+		return false, nil, nil
+	})
+}
+
+// capturePatchType records the k8s.io/apimachinery/pkg/types.PatchType of the
+// next patch on the given resource, so a test can prove which patch type was
+// actually sent to the client rather than only asserting on the resulting
+// object state (which is identical for a labels-only body regardless of type).
+func capturePatchType(client *k8sfake.Clientset, resource string, out *types.PatchType) {
+	client.PrependReactor("patch", resource, func(action clienttesting.Action) (bool, runtime.Object, error) {
+		*out = action.(clienttesting.PatchActionImpl).PatchType
 		return false, nil, nil
 	})
 }
@@ -383,4 +406,141 @@ func TestHandleOperatorAction_ValidTTLNotYetSupported(t *testing.T) {
 	err := ah.handleOperatorAction(context.Background())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ttl/auto-revert is not supported yet")
+}
+
+// patch without --confirm must default to a server-side dry-run, never a real
+// write — same safe-by-default contract as every other action.
+func TestHandleOperatorAction_PatchDefaultsToDryRun(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	var dryRun []string
+	capturePatchDryRun(client, "deployments", &dryRun)
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		// DryRun intentionally nil
+	}, map[string]any{
+		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a patch action without dryRun must default to server-side dry-run")
+}
+
+// patch --confirm applies the caller-supplied Strategic Merge Patch (the
+// default patchType) to the target.
+func TestHandleOperatorAction_PatchConfirmWritesStrategicMergePatch(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	var patchType types.PatchType
+	capturePatchType(client, "deployments", &patchType)
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	}, map[string]any{
+		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	assert.Equal(t, types.StrategicMergePatchType, patchType, "omitting patchType must default to Strategic Merge Patch")
+
+	got, err := client.AppsV1().Deployments("payments").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "applied", got.Labels["seccomp"])
+}
+
+// patch --confirm with patchType=merge sends a JSON Merge Patch rather than the
+// default Strategic Merge Patch.
+func TestHandleOperatorAction_PatchConfirmWritesJSONMergePatch(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	var patchType types.PatchType
+	capturePatchType(client, "deployments", &patchType)
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	}, map[string]any{
+		"patch":     `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+		"patchType": "merge",
+	})
+
+	require.NoError(t, ah.handleOperatorAction(context.Background()))
+	assert.Equal(t, types.MergePatchType, patchType, "patchType=merge must send a JSON Merge Patch, not the default Strategic Merge Patch")
+
+	got, err := client.AppsV1().Deployments("payments").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "applied", got.Labels["seccomp"])
+}
+
+// A patch action in an excluded namespace must be rejected before any write,
+// same as every other action.
+func TestHandleOperatorAction_PatchExcludedNamespace(t *testing.T) {
+	client := k8sfake.NewClientset()
+	cfg := newTestConfig(config.Config{Namespace: "kubescape", ExcludeNamespaces: []string{"kube-system"}})
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), cfg, apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "kube-system", Name: "api"},
+		DryRun: boolPtr(false),
+	}, map[string]any{
+		"patch": `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+	})
+
+	err := ah.handleOperatorAction(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "excluded from remediation")
+}
+
+// A patch action with no 'patch' payload in Command.Args is rejected before
+// any cluster write is attempted.
+func TestHandleOperatorAction_PatchMissingPayload(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+
+	ah := newActionHandlerForTest(t, client, newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	})
+
+	err := ah.handleOperatorAction(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires a 'patch' payload")
+}
+
+// An invalid JSON/YAML 'patch' payload is rejected at Plan time, before any
+// cluster write is attempted.
+func TestHandleOperatorAction_PatchInvalidPayload(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	}, map[string]any{
+		"patch": `{not valid: [`,
+	})
+
+	err := ah.handleOperatorAction(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid patch payload")
+}
+
+// An unsupported patchType is rejected before any cluster write is attempted.
+func TestHandleOperatorAction_PatchUnsupportedPatchType(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+
+	ah := newActionHandlerForTestWithExtraArgs(t, client, kssfake.NewSimpleClientset(), newTestConfig(config.Config{Namespace: "kubescape"}), apis.OperatorActionArgs{
+		Action: remediators.OperatorActionPatch,
+		Target: &apis.OperatorActionTarget{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		DryRun: boolPtr(false),
+	}, map[string]any{
+		"patch":     `{"metadata":{"labels":{"seccomp":"applied"}}}`,
+		"patchType": "json-patch",
+	})
+
+	err := ah.handleOperatorAction(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported patchType")
 }

--- a/mainhandler/remediators/patch.go
+++ b/mainhandler/remediators/patch.go
@@ -1,0 +1,333 @@
+package remediators
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/armosec/armoapi-go/apis"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+)
+
+// OperatorActionPatch is a generic Strategic Merge Patch / JSON Merge Patch
+// action: the backend sends a targeted patch body instead of the full desired
+// object. It is not yet part of armoapi-go's OperatorActionType enum, so it is
+// defined locally as a plain string constant of that type — comparisons and
+// map lookups against apis.OperatorActionType work the same either way.
+const OperatorActionPatch apis.OperatorActionType = "patch"
+
+// Patch type names accepted in Command.Args' "patchType" field. Strategic is
+// the default when patchType is omitted.
+const (
+	PatchTypeStrategic = "strategic"
+	PatchTypeMerge     = "merge"
+)
+
+// patchCaveat records the patch action's one operational precondition, echoed
+// into every Plan's Description so it survives into the OperatorCommand status
+// payload and the KubescapeRemediation audit event: a patch cannot be
+// automatically reverted because the operator does not record pre-patch state.
+const patchCaveat = "this patch cannot be automatically reverted (no prior state is recorded)"
+
+// maxPatchBytes bounds the accepted patch body. A remediation patch touches a
+// handful of fields (e.g. a seccompProfile); this is generous headroom while
+// still bounding the JSON/YAML decode cost of a hostile payload.
+const maxPatchBytes = 256 << 10 // 256 KiB
+
+// escalationPaths are podSpec-relative field paths a remediation patch must
+// never touch: each is independently sufficient to escalate from "patch a
+// workload's config" to node/cluster compromise (host namespaces, host
+// filesystem access via a hostPath volume, running as a different, possibly
+// more privileged, ServiceAccount, or pinning the workload to an attacker-
+// chosen node). This is defense-in-depth, not the primary control — the
+// primary control is that only an authorized caller should be able to reach
+// this action at all (RBAC on OperatorCommand / the trigger endpoint's own
+// authorization, both outside this package's scope).
+var escalationPaths = [][]string{
+	{"hostNetwork"},
+	{"hostPID"},
+	{"hostIPC"},
+	{"serviceAccountName"},
+	{"serviceAccount"},
+	{"volumes"},
+	{"nodeName"},
+}
+
+// escalationMetadataPaths are metadata-relative field paths a remediation
+// patch must never touch: a forged ownerReference lets a later garbage
+// collection delete the workload, and a finalizer can block its deletion.
+var escalationMetadataPaths = [][]string{
+	{"ownerReferences"},
+	{"finalizers"},
+}
+
+// patchTypeName maps a client-go patch media type back to the short vocabulary
+// used in Command.Args and error messages ("strategic"/"merge"), so a single
+// vocabulary is used throughout patch's user-visible strings.
+func patchTypeName(t types.PatchType) string {
+	switch t {
+	case types.MergePatchType:
+		return PatchTypeMerge
+	default:
+		return PatchTypeStrategic
+	}
+}
+
+// validatePatchType resolves patchType to its default (Strategic Merge Patch)
+// when empty and rejects anything other than the two types this action
+// supports.
+func validatePatchType(patchType types.PatchType) (types.PatchType, error) {
+	if patchType == "" {
+		patchType = types.StrategicMergePatchType
+	}
+	if patchType != types.StrategicMergePatchType && patchType != types.MergePatchType {
+		return "", fmt.Errorf("patch: unsupported patchType %q (supported: %s, %s)", patchType, PatchTypeStrategic, PatchTypeMerge)
+	}
+	return patchType, nil
+}
+
+// PatchRemediator applies an arbitrary caller-supplied patch to a single
+// workload. Unlike the other actions, the operator does not know the patch's
+// semantics up front — it is opaque, backend-authored content — so Plan only
+// validates shape (target kind/namespace, JSON/YAML well-formedness), and
+// Revert cannot reconstruct the pre-patch state.
+type PatchRemediator struct {
+	client kubernetes.Interface
+}
+
+// NewPatchRemediator returns a patch remediator backed by client.
+func NewPatchRemediator(client kubernetes.Interface) *PatchRemediator {
+	return &PatchRemediator{client: client}
+}
+
+// Plan validates the target and patch payload and returns the canonical
+// (JSON-encoded) patch body Apply would send.
+func (r *PatchRemediator) Plan(ctx context.Context, req Request) (Plan, error) {
+	if err := validateTarget(req.Target); err != nil {
+		return Plan{}, err
+	}
+	if !IsNamespacedKind(req.Target.Kind) {
+		return Plan{}, fmt.Errorf("patch: unsupported target kind %q (supported: Deployment, StatefulSet, DaemonSet, Pod)", req.Target.Kind)
+	}
+
+	patchType, err := validatePatchType(req.PatchType)
+	if err != nil {
+		return Plan{}, err
+	}
+
+	canonical, err := canonicalizePatch(req.Target.Kind, req.Patch)
+	if err != nil {
+		return Plan{}, fmt.Errorf("patch: invalid patch payload: %w", err)
+	}
+
+	return Plan{
+		Action:      string(OperatorActionPatch),
+		Target:      req.Target,
+		Description: fmt.Sprintf("patch %s (%s); %s", req.Target, patchTypeName(patchType), patchCaveat),
+		Patch:       canonical,
+		PatchType:   string(patchType),
+	}, nil
+}
+
+// Apply sends the planned patch. With dryRun=true it is a server-side dry-run
+// (validated against admission, never persisted); only dryRun=false writes.
+func (r *PatchRemediator) Apply(ctx context.Context, p Plan, dryRun bool) (Result, error) {
+	if err := validateTarget(p.Target); err != nil {
+		return Result{}, err
+	}
+	patchType, err := validatePatchType(types.PatchType(p.PatchType))
+	if err != nil {
+		return Result{}, err
+	}
+	if _, err := canonicalizePatch(p.Target.Kind, p.Patch); err != nil {
+		return Result{}, fmt.Errorf("patch: invalid patch payload: %w", err)
+	}
+
+	opts := metav1.PatchOptions{}
+	if dryRun {
+		opts.DryRun = []string{metav1.DryRunAll}
+	}
+	if err := r.patch(ctx, p.Target, patchType, []byte(p.Patch), opts); err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Action:      p.Action,
+		Target:      p.Target,
+		DryRun:      dryRun,
+		Applied:     !dryRun,
+		Description: p.Description,
+		Patch:       p.Patch,
+		PatchType:   p.PatchType,
+	}, nil
+}
+
+// Revert is not supported for arbitrary patches: the operator does not record
+// the pre-patch state, so there is nothing to reconstruct. Returning an error
+// (rather than a silent no-op) keeps the audit trail honest about the fact
+// that the target was not restored.
+func (r *PatchRemediator) Revert(ctx context.Context, t Target, dryRun bool) (Result, error) {
+	return Result{}, fmt.Errorf("patch: arbitrary patches on %s cannot be automatically reverted (no prior state is recorded)", t)
+}
+
+// patch applies a patch to the target object using the typed client for its
+// kind, with the given patch type and options.
+func (r *PatchRemediator) patch(ctx context.Context, t Target, patchType types.PatchType, patch []byte, opts metav1.PatchOptions) error {
+	switch strings.ToLower(t.Kind) {
+	case "deployment":
+		_, err := r.client.AppsV1().Deployments(t.Namespace).Patch(ctx, t.Name, patchType, patch, opts)
+		return err
+	case "statefulset":
+		_, err := r.client.AppsV1().StatefulSets(t.Namespace).Patch(ctx, t.Name, patchType, patch, opts)
+		return err
+	case "daemonset":
+		_, err := r.client.AppsV1().DaemonSets(t.Namespace).Patch(ctx, t.Name, patchType, patch, opts)
+		return err
+	case "pod":
+		_, err := r.client.CoreV1().Pods(t.Namespace).Patch(ctx, t.Name, patchType, patch, opts)
+		return err
+	default:
+		return fmt.Errorf("patch: unsupported target kind %q (supported: Deployment, StatefulSet, DaemonSet, Pod)", t.Kind)
+	}
+}
+
+// canonicalizePatch validates that raw is a well-formed, size-bounded JSON or
+// YAML object that does not touch an escalation-relevant field for the given
+// target kind, and returns its canonical JSON encoding. A patch body must be
+// an object (not a scalar or array): Strategic Merge Patch and JSON Merge
+// Patch are both object-shaped (unlike RFC 6902 JSON Patch, which this action
+// does not support).
+func canonicalizePatch(kind, raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("patch is empty")
+	}
+	if len(trimmed) > maxPatchBytes {
+		return "", fmt.Errorf("patch is too large (%d bytes, max %d)", len(trimmed), maxPatchBytes)
+	}
+	// YAML is a JSON superset, so this also accepts plain JSON input without
+	// needing to sniff the format first.
+	jsonBytes, err := yaml.YAMLToJSON([]byte(trimmed))
+	if err != nil {
+		return "", err
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(jsonBytes, &obj); err != nil {
+		return "", fmt.Errorf("patch must be a JSON/YAML object: %w", err)
+	}
+	// json.Unmarshal accepts a literal "null" (or YAML "~") into a nil map
+	// without error, which would otherwise be applied as a guaranteed no-op
+	// reported as Applied: true.
+	if len(obj) == 0 {
+		return "", fmt.Errorf("patch must be a non-empty JSON/YAML object")
+	}
+	if err := rejectEscalation(kind, obj); err != nil {
+		return "", err
+	}
+	return string(jsonBytes), nil
+}
+
+// podSpecPath is the patch-relative path to the pod spec for kind: nested
+// under spec.template.spec for the three controller kinds, or spec directly
+// for a bare Pod.
+func podSpecPath(kind string) []string {
+	if strings.EqualFold(kind, "pod") {
+		return []string{"spec"}
+	}
+	return []string{"spec", "template", "spec"}
+}
+
+// rejectEscalation rejects a patch that touches a field this action treats as
+// escalation-relevant (see escalationPaths/escalationMetadataPaths), at either
+// the pod-spec level (hostNetwork, volumes, serviceAccountName, ...) or the
+// container level (privileged, added capabilities, image).
+func rejectEscalation(kind string, obj map[string]any) error {
+	for _, p := range escalationMetadataPaths {
+		if hasPath(obj, append([]string{"metadata"}, p...)) {
+			return fmt.Errorf("patch: field %q is not allowed in a remediation patch", "metadata."+strings.Join(p, "."))
+		}
+	}
+	podSpec := podSpecPath(kind)
+	for _, p := range escalationPaths {
+		if hasPath(obj, append(append([]string{}, podSpec...), p...)) {
+			return fmt.Errorf("patch: field %q is not allowed in a remediation patch", strings.Join(podSpec, ".")+"."+strings.Join(p, "."))
+		}
+	}
+	for _, containersField := range []string{"containers", "initContainers"} {
+		containers, ok := valueAtPath(obj, append(append([]string{}, podSpec...), containersField))
+		if !ok {
+			continue
+		}
+		list, ok := containers.([]any)
+		if !ok {
+			continue
+		}
+		for _, c := range list {
+			container, ok := c.(map[string]any)
+			if !ok {
+				continue
+			}
+			if err := rejectContainerEscalation(container); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// rejectContainerEscalation rejects an image change (a remediation patch
+// fixes configuration, not workload content) and container-level
+// securityContext escalations (privileged, added capabilities, or explicitly
+// enabling privilege escalation).
+func rejectContainerEscalation(container map[string]any) error {
+	if _, ok := container["image"]; ok {
+		return fmt.Errorf("patch: field \"image\" is not allowed in a remediation patch")
+	}
+	sc, ok := container["securityContext"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	if privileged, ok := sc["privileged"].(bool); ok && privileged {
+		return fmt.Errorf("patch: securityContext.privileged=true is not allowed in a remediation patch")
+	}
+	if allowEscalation, ok := sc["allowPrivilegeEscalation"].(bool); ok && allowEscalation {
+		return fmt.Errorf("patch: securityContext.allowPrivilegeEscalation=true is not allowed in a remediation patch")
+	}
+	if capabilities, ok := sc["capabilities"].(map[string]any); ok {
+		if _, ok := capabilities["add"]; ok {
+			return fmt.Errorf("patch: securityContext.capabilities.add is not allowed in a remediation patch")
+		}
+	}
+	return nil
+}
+
+// hasPath reports whether path resolves to any value (including null) in m.
+func hasPath(m map[string]any, path []string) bool {
+	_, ok := valueAtPath(m, path)
+	return ok
+}
+
+// valueAtPath walks path through nested maps and returns the value found at
+// its end, if any. It stops (returning false) as soon as an intermediate
+// segment is missing or is not itself a map.
+func valueAtPath(m map[string]any, path []string) (any, bool) {
+	cur := m
+	for i, k := range path {
+		v, ok := cur[k]
+		if !ok {
+			return nil, false
+		}
+		if i == len(path)-1 {
+			return v, true
+		}
+		next, ok := v.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return nil, false
+}

--- a/mainhandler/remediators/patch.go
+++ b/mainhandler/remediators/patch.go
@@ -13,13 +13,6 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// OperatorActionPatch is a generic Strategic Merge Patch / JSON Merge Patch
-// action: the backend sends a targeted patch body instead of the full desired
-// object. It is not yet part of armoapi-go's OperatorActionType enum, so it is
-// defined locally as a plain string constant of that type — comparisons and
-// map lookups against apis.OperatorActionType work the same either way.
-const OperatorActionPatch apis.OperatorActionType = "patch"
-
 // Patch type names accepted in Command.Args' "patchType" field. Strategic is
 // the default when patchType is omitted.
 const (
@@ -125,7 +118,7 @@ func (r *PatchRemediator) Plan(ctx context.Context, req Request) (Plan, error) {
 	}
 
 	return Plan{
-		Action:      string(OperatorActionPatch),
+		Action:      string(apis.OperatorActionPatch),
 		Target:      req.Target,
 		Description: fmt.Sprintf("patch %s (%s); %s", req.Target, patchTypeName(patchType), patchCaveat),
 		Patch:       canonical,

--- a/mainhandler/remediators/patch_test.go
+++ b/mainhandler/remediators/patch_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/armosec/armoapi-go/apis"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -25,7 +26,7 @@ func TestPatchPlan_ValidStrategicMergePatch(t *testing.T) {
 		Patch:  `{"spec":{"template":{"spec":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}}}`,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, string(OperatorActionPatch), plan.Action)
+	assert.Equal(t, string(apis.OperatorActionPatch), plan.Action)
 	assert.Equal(t, "Deployment/payments/api", plan.Target.String())
 	assert.Equal(t, string(types.StrategicMergePatchType), plan.PatchType)
 	assert.JSONEq(t, `{"spec":{"template":{"spec":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}}}`, plan.Patch)
@@ -279,7 +280,7 @@ func TestPatchApply_RejectsEscalationFieldsEvenWithHandcraftedPlan(t *testing.T)
 	// A Plan built out of band (bypassing Plan()) must still be rejected by
 	// Apply — validation belongs at the boundary that performs the write.
 	_, err := r.Apply(context.Background(), Plan{
-		Action: string(OperatorActionPatch),
+		Action: string(apis.OperatorActionPatch),
 		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
 		Patch:  `{"spec":{"template":{"spec":{"hostNetwork":true}}}}`,
 	}, false)

--- a/mainhandler/remediators/patch_test.go
+++ b/mainhandler/remediators/patch_test.go
@@ -1,0 +1,287 @@
+package remediators
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func podForPatch(ns, name string) *corev1.Pod {
+	return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+}
+
+func TestPatchPlan_ValidStrategicMergePatch(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"spec":{"template":{"spec":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}}}`,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(OperatorActionPatch), plan.Action)
+	assert.Equal(t, "Deployment/payments/api", plan.Target.String())
+	assert.Equal(t, string(types.StrategicMergePatchType), plan.PatchType)
+	assert.JSONEq(t, `{"spec":{"template":{"spec":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}}}`, plan.Patch)
+}
+
+func TestPatchPlan_YAMLPatchIsCanonicalizedToJSON(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	yamlPatch := "spec:\n  template:\n    spec:\n      securityContext:\n        seccompProfile:\n          type: RuntimeDefault\n"
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Pod", Namespace: "payments", Name: "api"},
+		Patch:  yamlPatch,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"spec":{"template":{"spec":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}}}`, plan.Patch)
+}
+
+func TestPatchPlan_MergePatchType(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	plan, err := r.Plan(context.Background(), Request{
+		Target:    Target{Kind: "StatefulSet", Namespace: "payments", Name: "db"},
+		Patch:     `{"metadata":{"labels":{"foo":"bar"}}}`,
+		PatchType: types.MergePatchType,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(types.MergePatchType), plan.PatchType)
+}
+
+func TestPatchPlan_InvalidJSON(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{not valid json or yaml: [`,
+	})
+	require.Error(t, err)
+}
+
+func TestPatchPlan_EmptyPatch(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  "",
+	})
+	require.Error(t, err)
+}
+
+func TestPatchPlan_PatchMustBeObjectNotArray(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `[{"op":"replace","path":"/spec","value":{}}]`,
+	})
+	require.Error(t, err, "JSON Patch (RFC 6902) arrays are not supported by this action")
+}
+
+func TestPatchPlan_UnsupportedKind(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Node", Name: "node-1"},
+		Patch:  `{"metadata":{"labels":{"foo":"bar"}}}`,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported target kind")
+}
+
+func TestPatchPlan_UnsupportedPatchType(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target:    Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:     `{"metadata":{"labels":{"foo":"bar"}}}`,
+		PatchType: types.JSONPatchType,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported patchType")
+}
+
+func TestPatchPlan_RequiresKindAndName(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{Target: Target{Name: "api"}, Patch: `{}`})
+	require.Error(t, err)
+}
+
+func TestPatchApply_DryRunDoesNotPersist(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	var dryRun []string
+	capturePatchDryRun(client, "deployments", &dryRun)
+
+	r := NewPatchRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"foo":"bar"}}}`,
+	})
+	require.NoError(t, err)
+
+	result, err := r.Apply(context.Background(), plan, true)
+	require.NoError(t, err)
+	assert.True(t, result.DryRun)
+	assert.False(t, result.Applied)
+	assert.Equal(t, []string{metav1.DryRunAll}, dryRun, "a dry-run apply must request server-side dry-run")
+}
+
+func TestPatchApply_ConfirmedWritesDeployment(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	r := NewPatchRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"foo":"bar"}}}`,
+	})
+	require.NoError(t, err)
+
+	result, err := r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	assert.True(t, result.Applied)
+	assert.False(t, result.DryRun)
+
+	got, err := client.AppsV1().Deployments("payments").Get(context.Background(), "api", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "bar", got.Labels["foo"])
+}
+
+func TestPatchApply_ConfirmedWritesPod(t *testing.T) {
+	client := k8sfake.NewClientset(podForPatch("payments", "worker"))
+	r := NewPatchRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Pod", Namespace: "payments", Name: "worker"},
+		Patch:  `{"metadata":{"labels":{"foo":"bar"}}}`,
+	})
+	require.NoError(t, err)
+
+	result, err := r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	assert.True(t, result.Applied)
+
+	got, err := client.CoreV1().Pods("payments").Get(context.Background(), "worker", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "bar", got.Labels["foo"])
+}
+
+func TestPatchApply_UnsupportedKindFails(t *testing.T) {
+	client := k8sfake.NewClientset()
+	r := NewPatchRemediator(client)
+	_, err := r.Apply(context.Background(), Plan{
+		Target: Target{Kind: "Node", Name: "node-1"},
+		Patch:  `{"metadata":{"labels":{"foo":"bar"}}}`,
+	}, false)
+	require.Error(t, err)
+}
+
+func TestPatchRevert_ReturnsInformativeError(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Revert(context.Background(), Target{Kind: "Deployment", Namespace: "payments", Name: "api"}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot be automatically reverted")
+}
+
+func TestPatchApply_RecordsPatchInResultForAudit(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	r := NewPatchRemediator(client)
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"metadata":{"labels":{"foo":"bar"}}}`,
+	})
+	require.NoError(t, err)
+
+	result, err := r.Apply(context.Background(), plan, false)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"metadata":{"labels":{"foo":"bar"}}}`, result.Patch, "the applied patch body must be recorded on Result for the audit trail")
+	assert.Equal(t, string(types.StrategicMergePatchType), result.PatchType)
+}
+
+func TestPatchPlan_RejectsNullPatch(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  "null",
+	})
+	require.Error(t, err)
+}
+
+func TestPatchPlan_RejectsEmptyObjectPatch(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  "{}",
+	})
+	require.Error(t, err)
+}
+
+func TestPatchPlan_RejectsOversizedPatch(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	huge := `{"metadata":{"labels":{"foo":"` + strings.Repeat("a", maxPatchBytes) + `"}}}`
+	_, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  huge,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too large")
+}
+
+// Escalation-relevant fields must be rejected regardless of patch type, on
+// every supported workload kind: they would let a caller convert this action's
+// cluster-wide patch RBAC into node or cluster compromise.
+func TestPatchPlan_RejectsEscalationFields(t *testing.T) {
+	cases := []struct {
+		name  string
+		kind  string
+		patch string
+	}{
+		{"hostNetwork on Deployment", "Deployment", `{"spec":{"template":{"spec":{"hostNetwork":true}}}}`},
+		{"hostPID on StatefulSet", "StatefulSet", `{"spec":{"template":{"spec":{"hostPID":true}}}}`},
+		{"hostIPC on DaemonSet", "DaemonSet", `{"spec":{"template":{"spec":{"hostIPC":true}}}}`},
+		{"serviceAccountName on Deployment", "Deployment", `{"spec":{"template":{"spec":{"serviceAccountName":"cluster-admin-sa"}}}}`},
+		{"volumes (hostPath) on Deployment", "Deployment", `{"spec":{"template":{"spec":{"volumes":[{"name":"h","hostPath":{"path":"/"}}]}}}}`},
+		{"nodeName on Deployment", "Deployment", `{"spec":{"template":{"spec":{"nodeName":"node-1"}}}}`},
+		{"hostNetwork on Pod", "Pod", `{"spec":{"hostNetwork":true}}`},
+		{"serviceAccountName on Pod", "Pod", `{"spec":{"serviceAccountName":"cluster-admin-sa"}}`},
+		{"ownerReferences", "Deployment", `{"metadata":{"ownerReferences":[{"apiVersion":"v1","kind":"Node","name":"n","uid":"x"}]}}`},
+		{"finalizers", "Deployment", `{"metadata":{"finalizers":["evil.example.com/hold"]}}`},
+		{"container privileged", "Deployment", `{"spec":{"template":{"spec":{"containers":[{"name":"api","securityContext":{"privileged":true}}]}}}}`},
+		{"container allowPrivilegeEscalation", "Deployment", `{"spec":{"template":{"spec":{"containers":[{"name":"api","securityContext":{"allowPrivilegeEscalation":true}}]}}}}`},
+		{"container added capabilities", "Deployment", `{"spec":{"template":{"spec":{"containers":[{"name":"api","securityContext":{"capabilities":{"add":["SYS_ADMIN"]}}}]}}}}`},
+		{"container image change", "Deployment", `{"spec":{"template":{"spec":{"containers":[{"name":"api","image":"attacker/img"}]}}}}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := NewPatchRemediator(k8sfake.NewClientset())
+			_, err := r.Plan(context.Background(), Request{
+				Target: Target{Kind: c.kind, Namespace: "payments", Name: "api"},
+				Patch:  c.patch,
+			})
+			require.Error(t, err, "escalation-relevant field must be rejected")
+			assert.Contains(t, err.Error(), "not allowed")
+		})
+	}
+}
+
+// A patch touching only non-escalation-relevant fields must still be accepted
+// — the denylist must not be so broad it blocks the feature's own use case.
+func TestPatchPlan_AllowsNonEscalationFields(t *testing.T) {
+	r := NewPatchRemediator(k8sfake.NewClientset())
+	plan, err := r.Plan(context.Background(), Request{
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"spec":{"template":{"spec":{"containers":[{"name":"api","securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}]}}}}`,
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, plan.Patch)
+}
+
+func TestPatchApply_RejectsEscalationFieldsEvenWithHandcraftedPlan(t *testing.T) {
+	client := k8sfake.NewClientset(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "payments", Name: "api"}})
+	r := NewPatchRemediator(client)
+	// A Plan built out of band (bypassing Plan()) must still be rejected by
+	// Apply — validation belongs at the boundary that performs the write.
+	_, err := r.Apply(context.Background(), Plan{
+		Action: string(OperatorActionPatch),
+		Target: Target{Kind: "Deployment", Namespace: "payments", Name: "api"},
+		Patch:  `{"spec":{"template":{"spec":{"hostNetwork":true}}}}`,
+	}, false)
+	require.Error(t, err)
+}

--- a/mainhandler/remediators/remediator.go
+++ b/mainhandler/remediators/remediator.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"github.com/armosec/armoapi-go/apis"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -37,6 +38,11 @@ type Request struct {
 	Target     Target
 	Reason     string
 	FindingRef string
+	// Patch and PatchType are used by the patch action only: Patch is the raw
+	// (JSON or YAML) patch body, and PatchType selects Strategic Merge Patch
+	// (the default, when empty) or JSON Merge Patch.
+	Patch     string
+	PatchType types.PatchType
 }
 
 // Plan is the computed, not-yet-applied effect of a remediation. It is returned
@@ -49,6 +55,9 @@ type Plan struct {
 	// Patch is the exact patch body Apply would send, included for transparency
 	// in the dry-run preview.
 	Patch string `json:"patch,omitempty"`
+	// PatchType is the patch action's patch type (Strategic Merge Patch or
+	// JSON Merge Patch), empty for actions other than patch.
+	PatchType string `json:"patchType,omitempty"`
 }
 
 // Result is the outcome of Apply or Revert.
@@ -58,6 +67,12 @@ type Result struct {
 	DryRun      bool   `json:"dryRun"`
 	Applied     bool   `json:"applied"`
 	Description string `json:"description"`
+	// Patch and PatchType record the exact bytes and patch type a confirmed
+	// (non-dry-run) patch action sent to the API server, so the audit trail
+	// (OperatorCommand status + KubescapeRemediation event) can reconstruct
+	// what changed. Empty for actions other than patch.
+	Patch     string `json:"patch,omitempty"`
+	PatchType string `json:"patchType,omitempty"`
 }
 
 // Remediator computes and performs a single class of cluster operation.
@@ -80,5 +95,6 @@ func NewRegistry(client kubernetes.Interface) map[apis.OperatorActionType]Remedi
 	return map[apis.OperatorActionType]Remediator{
 		apis.OperatorActionAnnotate:   NewAnnotateRemediator(client),
 		apis.OperatorActionQuarantine: NewQuarantineRemediator(client),
+		OperatorActionPatch:           NewPatchRemediator(client),
 	}
 }

--- a/mainhandler/remediators/remediator.go
+++ b/mainhandler/remediators/remediator.go
@@ -95,6 +95,6 @@ func NewRegistry(client kubernetes.Interface) map[apis.OperatorActionType]Remedi
 	return map[apis.OperatorActionType]Remediator{
 		apis.OperatorActionAnnotate:   NewAnnotateRemediator(client),
 		apis.OperatorActionQuarantine: NewQuarantineRemediator(client),
-		OperatorActionPatch:           NewPatchRemediator(client),
+		apis.OperatorActionPatch:      NewPatchRemediator(client),
 	}
 }


### PR DESCRIPTION
## Overview

Adds a `patch` action to `TypeOperatorAction`, alongside the existing `annotate`, `quarantine`, and `revert` actions. It lets the backend apply a targeted Strategic Merge Patch or JSON Merge Patch (e.g. injecting `securityContext.seccompProfile`) to a Deployment/StatefulSet/DaemonSet/Pod without knowing or sending the workload's full YAML.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

## ⚠️ Security: read before enabling this action

An automated security review flagged that `/v1/triggerAction` (`restapihandler/triggeraction.go`) has **no application-level caller authentication**, and its Service carries no `NetworkPolicy` — I verified live (on `armo-dev-stage`) that an anonymous, tokenless POST from an unrelated in-cluster pod reaches it and gets processed. Before this change, a caller there could only trigger `annotate`/`quarantine` (hardcoded, low-blast-radius writes); `patch` would have let that same caller direct the operator's cluster-wide `patch` RBAC at arbitrary workload fields, bounded only by the denylist below.

**Fixed in this PR** — but not the way the first attempt did it: I initially tried allowlisting the endpoint's `commandName`s, excluding `operatorAction` entirely. That would have broken a real, shipped feature: `/v1/triggerAction` is the **documented, intended transport** for the `kubescape` CLI's `operator remediate annotate|quarantine|revert` subcommand (see [`designs-and-proposals/cli-cluster-operations.md`](https://github.com/kubescape/designs-and-proposals/blob/50e4e2b15857595469bf82cc0246dea820a6020a/proposals/cli-cluster-operations.md)), reached via `kubectl port-forward` — itself RBAC-gated (`pods/portforward`).

`patch` was never part of that design (its action set is `annotate`/`quarantine`/`cordon`/`revert`) and has no CLI subcommand or other legitimate use of `/v1/triggerAction`. So instead of an allowlist, `handleOperatorAction` now rejects `patch` outright unless `sessionObj.ParentCommandDetails` is set — the existing signal in this codebase for "this command arrived via the `OperatorCommand` CRD watcher," not `/v1/triggerAction`. `annotate`/`quarantine`/`revert` are unaffected and keep working exactly as before, including via the CLI.

**What this does *not* fix** (tracked separately, not blocking this PR):
- The endpoint's underlying lack of auth for `annotate`/`quarantine`/`revert` themselves is unchanged — pre-existing, not introduced here. The real fix is a `NetworkPolicy` in `kubescape/helm-charts` restricting Service-level ingress to port 4002 (`kubectl port-forward` traffic doesn't cross the pod network a `NetworkPolicy` governs, so it wouldn't break the CLI).
- The escalation denylist below is best-effort, not exhaustive — e.g. it doesn't currently block `automountServiceAccountToken` or `ephemeralContainers`.
- Who holds `create`/`update` RBAC on `operatorcommands.kubescape.io` in a given deployment hasn't been independently audited here.

## What's in this PR

- `PatchRemediator` (`mainhandler/remediators/patch.go`): implements `Plan`/`Apply`/`Revert`, enforces the same safe-by-default + excluded-namespace rails as every other action, plus patch-specific hardening applied in both `Plan` and `Apply` (so a hand-built `Plan` can't skip it):
  - 256KiB size cap
  - rejects `null`/empty-object/array (RFC 6902 JSON Patch) bodies
  - **escalation denylist**: `hostNetwork`/`hostPID`/`hostIPC`, `serviceAccountName`, `volumes`, `nodeName`, `metadata.ownerReferences`/`finalizers`, container `privileged`/`allowPrivilegeEscalation`/added `capabilities`, and container `image` changes are all rejected
- **`patch` is only dispatchable via the `OperatorCommand` CRD delivery path** (`mainhandler/actionhandler.go`): rejected outright if `sessionObj.ParentCommandDetails` is nil, i.e. if it arrived via `/v1/triggerAction` instead — see the security section above
- `Revert` on a patched target now explicitly records that the patch was **not** reverted (arbitrary patches carry no recorded pre-state) instead of implying success
- Applied patch content is recorded on `Result` so the `OperatorCommand` status payload / `KubescapeRemediation` audit event can reconstruct what changed
- `docs/features/patch-remediation-action.md` — full command shape, safety rails, and the delivery-path restriction above

## How to test

```
go build ./...
go vet ./...
go test ./mainhandler/... -v
```

New tests cover: valid strategic/merge patches, YAML→JSON canonicalization, dry-run vs confirmed writes, every escalation-denylist field on each supported kind, size/shape rejection, unsupported kind/patchType, revert's informative error, end-to-end command dispatch (safety rails, missing/invalid payload, both patch types), and the CRD-origin delivery gate (`patch` rejected and never reaching the client when simulating `/v1/triggerAction` delivery; `annotate` proven unaffected by the same gate).

## Additional information

This PR was developed with Claude Code, including an automated code-quality review and an automated security review; findings from both were addressed in the commit (see commit messages for details).

The delivery-path fix above went through two iterations: [#411](https://github.com/kubescape/operator/pull/411) initially tried an endpoint-wide `commandName` allowlist excluding `operatorAction`, which would have broken the CLI's `operator remediate` feature — it's closed in favor of the narrower, `patch`-specific fix here, once the CLI's dependency on `/v1/triggerAction` came to light. [#412](https://github.com/kubescape/operator/issues/412) tracks the remaining, non-blocking follow-up (migrating the scan-scheduling CronJobs off that endpoint, and a `NetworkPolicy`-based fix for its broader lack of auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MmNHibtv3BGpGLqzWYgwQ

AI-skills: oh-my-claudecode:cancel | cmds: /oh-my-claudecode:autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `patch` remediation action for supported Kubernetes workloads.
  * Supports strategic merge and JSON merge patches, with server-side dry-run by default.
  * Validates patch format, size, target scope, patch type, and escalation-sensitive changes.
  * Records patch details and type in remediation results for auditing.
  * Patch actions are available only through the OperatorCommand workflow.
  * Patch actions cannot be automatically reverted; results report this limitation.

* **Documentation**
  * Added guidance covering usage, safety controls, auditing, delivery restrictions, and revert limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
