### PR TITLE
fix(restapi): allowlist commandName on the unauthenticated triggerAction endpoint

### DIFF
--- a/docs/features/trigger-action-command-allowlist.md
+++ b/docs/features/trigger-action-command-allowlist.md
@@ -1,0 +1,52 @@
+# triggerAction command allowlist
+
+## Overview
+
+`/v1/triggerAction` (`restapihandler/triggeraction.go`, port `4002`, named
+`trigger-port`) is an unauthenticated HTTP endpoint: it has no caller
+identity check, and its Service has no NetworkPolicy restricting who can
+reach it. It now only dispatches an explicit allowlist of `CommandName`
+values instead of every command the operator recognizes.
+
+## Why
+
+The endpoint's only legitimate callers are the operator's own
+scan-scheduling CronJobs, run in-cluster with a fixed, hardcoded request
+body:
+
+| CronJob | `commandName` sent |
+|---|---|
+| `kubescape-scheduler` | `kubescapeScan` (`apis.TypeRunKubescape`) |
+| `kubevuln-scheduler` | `scan` (`apis.TypeScanImages`) |
+| registry-scan CronJob (created dynamically when registry scanning is configured — see `watcher/registryhandler.go`) | `scanRegistryV2` (`apis.TypeScanRegistryV2`) |
+
+Before this change, the endpoint's shared dispatcher (`handleRequest` in
+`mainhandler/handlerequests.go`) accepted every `CommandName` it recognizes,
+including `operatorAction` — the command type that drives remediation
+(`annotate`/`quarantine`/`revert`/`patch`). Because nothing gates who can
+reach port 4002, any pod on the cluster network could send an `operatorAction`
+command and have the operator apply it with its own cluster-wide remediation
+RBAC — a materially different risk than the legitimate callers' fixed,
+read-only-triggering payloads.
+
+This is a stopgap: the real fix is to stop using an unauthenticated HTTP
+callback for this at all, and have these CronJobs create `OperatorCommand`
+custom resources directly instead (the same, RBAC-gated mechanism the
+`synchronizer` component already uses for backend-originated commands). That
+migration is tracked separately since it requires Helm chart changes.
+
+## What changed
+
+`restapihandler/triggeraction.go` now checks each command's `CommandName`
+against `triggerActionAllowedCommands` before dispatching it to the worker
+pool. A command whose name isn't in that set is rejected the same way an
+empty `CommandName` already was: logged, recorded as an error on its
+`OperatorCommand` status (a no-op for a command that didn't originate from a
+CRD, which is always true here), and skipped — it never reaches
+`handleRequest`. The HTTP response is unaffected (`200`/`ok`), matching the
+endpoint's existing behavior for other per-command validation failures; the
+allowlist rejects the *dispatch*, not the HTTP request.
+
+`apis.TypeOperatorAction` is deliberately excluded, so `operatorAction`
+(and therefore `patch` — see `docs/features/patch-remediation-action.md`)
+can only ever be dispatched via the RBAC-gated `OperatorCommand` CRD path.

--- a/restapihandler/triggeraction.go
+++ b/restapihandler/triggeraction.go
@@ -13,6 +13,29 @@ import (
 	"github.com/kubescape/operator/utils"
 )
 
+// triggerActionAllowedCommands is the exact set of CommandNames
+// /v1/triggerAction is permitted to dispatch.
+//
+// This endpoint has no caller authentication: unlike the OperatorCommand CRD
+// path (only reachable through the synchronizer ServiceAccount's own K8s
+// RBAC, itself gated behind an authenticated connection to the backend),
+// anything on the pod network that can reach the operator's Service on this
+// port can call it. Its only legitimate callers are the operator's own
+// scan-scheduling CronJobs — kubescape-scheduler (kubescapeScan),
+// kubevuln-scheduler (scan), and the dynamically created registry-scan
+// CronJob (scanRegistryV2, see watcher/registryhandler.go) — none of which
+// ever send anything else.
+//
+// apis.TypeOperatorAction is deliberately excluded: it drives remediation
+// actions (annotate/quarantine/revert/patch) that can mutate arbitrary
+// cluster workloads, and must only ever be dispatched via the RBAC-gated
+// OperatorCommand CRD path, never through this unauthenticated endpoint.
+var triggerActionAllowedCommands = map[apis.NotificationPolicyType]bool{
+	apis.TypeRunKubescape:   true,
+	apis.TypeScanImages:     true,
+	apis.TypeScanRegistryV2: true,
+}
+
 /*args may contain credentials*/
 func displayReceivedCommand(receivedCommands []byte) {
 
@@ -47,6 +70,12 @@ func (resthandler *HTTPHandler) HandleActionRequest(ctx context.Context, receive
 		sessionObj := utils.NewSessionObj(ctx, resthandler.config, &c, c.JobTracking.ParentID, c.JobTracking.JobID)
 		if c.CommandName == "" {
 			err := fmt.Errorf("command not found. id: %s", c.GetID())
+			logger.L().Ctx(ctx).Error(err.Error(), helpers.Error(err))
+			sessionObj.SetOperatorCommandStatus(ctx, utils.WithError(err))
+			continue
+		}
+		if !triggerActionAllowedCommands[c.CommandName] {
+			err := fmt.Errorf("command %q is not allowed via triggerAction. id: %s", c.CommandName, c.GetID())
 			logger.L().Ctx(ctx).Error(err.Error(), helpers.Error(err))
 			sessionObj.SetOperatorCommandStatus(ctx, utils.WithError(err))
 			continue

--- a/restapihandler/triggeraction_test.go
+++ b/restapihandler/triggeraction_test.go
@@ -1,0 +1,159 @@
+package restapihandler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/armosec/armoapi-go/apis"
+	utilsmetadata "github.com/armosec/utils-k8s-go/armometadata"
+	beUtils "github.com/kubescape/backend/pkg/utils"
+	"github.com/kubescape/operator/config"
+	"github.com/panjf2000/ants/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	dispatchWaitTimeout  = 300 * time.Millisecond
+	dispatchPollInterval = 5 * time.Millisecond
+)
+
+// assertNeverDispatched asserts counter stays at 0 for the whole poll window,
+// not just immediately: the worker pool schedules jobs asynchronously, so a
+// naive immediate check could pass even if dispatch happens moments later.
+func assertNeverDispatched(t *testing.T, counter *int32Counter) {
+	t.Helper()
+	assert.Never(t, func() bool { return counter.get() != 0 }, dispatchWaitTimeout, dispatchPollInterval, "a rejected command must never reach the worker pool")
+}
+
+func newTestConfig(t *testing.T) config.IConfig {
+	t.Helper()
+	return config.NewOperatorConfig(config.CapabilitiesConfig{}, utilsmetadata.ClusterConfig{}, &beUtils.Credentials{}, config.Config{Namespace: "kubescape"})
+}
+
+// newCountingPool returns a pool that increments count for every job it
+// receives, so a test can assert whether triggerAction actually dispatched a
+// command (rather than only checking the HTTP-level response, which is
+// always "ok" regardless of whether a command was rejected — see ActionRequest).
+func newCountingPool(t *testing.T) (*ants.PoolWithFunc, *int32Counter) {
+	t.Helper()
+	counter := &int32Counter{}
+	pool, err := ants.NewPoolWithFunc(4, func(i any) {
+		counter.inc()
+	})
+	require.NoError(t, err)
+	t.Cleanup(pool.Release)
+	return pool, counter
+}
+
+type int32Counter struct {
+	mu    sync.Mutex
+	value int
+}
+
+func (c *int32Counter) inc() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.value++
+}
+
+func (c *int32Counter) get() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.value
+}
+
+// The endpoint has no caller authentication, so its dispatch surface must be
+// limited to exactly the commands its legitimate callers (the operator's own
+// scan-scheduling CronJobs) send. This test locks in that allowlist.
+func TestTriggerActionAllowedCommands(t *testing.T) {
+	assert.Equal(t, map[apis.NotificationPolicyType]bool{
+		apis.TypeRunKubescape:   true, // kubescape-scheduler
+		apis.TypeScanImages:     true, // kubevuln-scheduler
+		apis.TypeScanRegistryV2: true, // registry scan CronJob
+	}, triggerActionAllowedCommands)
+	assert.False(t, triggerActionAllowedCommands[apis.TypeOperatorAction], "operatorAction (and therefore patch/annotate/quarantine/revert) must never be dispatchable via the unauthenticated triggerAction endpoint")
+}
+
+func TestHandleActionRequest_AllowedCommandIsDispatched(t *testing.T) {
+	pool, counter := newCountingPool(t)
+	resthandler := NewHTTPHandler(pool, newTestConfig(t))
+
+	body := `{"commands":[{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}]}`
+	require.NoError(t, resthandler.HandleActionRequest(context.Background(), []byte(body)))
+
+	require.Eventually(t, func() bool { return counter.get() == 1 }, dispatchWaitTimeout, dispatchPollInterval, "an allowed command must be dispatched to the worker pool")
+}
+
+func TestHandleActionRequest_OperatorActionIsRejected(t *testing.T) {
+	pool, counter := newCountingPool(t)
+	resthandler := NewHTTPHandler(pool, newTestConfig(t))
+
+	// The exact shape a caller would need to trigger the new "patch" action —
+	// must never reach the worker pool through this endpoint.
+	body := `{"commands":[{"commandName":"operatorAction","args":{"action":"patch","dryRun":false,"target":{"kind":"Deployment","namespace":"payments","name":"api"},"patch":"{\"metadata\":{\"labels\":{\"pwned\":\"true\"}}}"}}]}`
+	require.NoError(t, resthandler.HandleActionRequest(context.Background(), []byte(body)))
+
+	assertNeverDispatched(t, counter)
+}
+
+func TestHandleActionRequest_UnknownCommandIsRejected(t *testing.T) {
+	pool, counter := newCountingPool(t)
+	resthandler := NewHTTPHandler(pool, newTestConfig(t))
+
+	body := `{"commands":[{"commandName":"deleteEverything"}]}`
+	require.NoError(t, resthandler.HandleActionRequest(context.Background(), []byte(body)))
+
+	assertNeverDispatched(t, counter)
+}
+
+func TestHandleActionRequest_EmptyCommandNameIsRejected(t *testing.T) {
+	pool, counter := newCountingPool(t)
+	resthandler := NewHTTPHandler(pool, newTestConfig(t))
+
+	body := `{"commands":[{"commandName":""}]}`
+	require.NoError(t, resthandler.HandleActionRequest(context.Background(), []byte(body)))
+
+	assertNeverDispatched(t, counter)
+}
+
+// A batch mixing an allowed and a disallowed command must dispatch only the
+// allowed one — one bad command must not block or be conflated with the rest.
+func TestHandleActionRequest_MixedBatchDispatchesOnlyAllowed(t *testing.T) {
+	pool, counter := newCountingPool(t)
+	resthandler := NewHTTPHandler(pool, newTestConfig(t))
+
+	body := `{"commands":[
+		{"commandName":"operatorAction","args":{"action":"patch"}},
+		{"commandName":"scan","designators":[{"designatorType":"Attributes","attributes":{}}]}
+	]}`
+	require.NoError(t, resthandler.HandleActionRequest(context.Background(), []byte(body)))
+
+	require.Eventually(t, func() bool { return counter.get() == 1 }, dispatchWaitTimeout, dispatchPollInterval, "exactly the allowed command in the batch must be dispatched")
+}
+
+// End-to-end HTTP-level check: the endpoint still returns 200/"ok" for a
+// rejected command (matching its existing behavior for e.g. an empty
+// commandName) — the allowlist rejects the *dispatch*, it isn't surfaced as
+// an HTTP error. This is what a live probe against the real endpoint would
+// observe, so this test documents that shape rather than treating the
+// rejection as invisible.
+func TestActionRequest_RejectedCommandStillReturnsOK(t *testing.T) {
+	pool, counter := newCountingPool(t)
+	resthandler := NewHTTPHandler(pool, newTestConfig(t))
+
+	body := `{"commands":[{"commandName":"operatorAction","args":{"action":"patch"}}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/triggerAction", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	resthandler.ActionRequest(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "ok", rec.Body.String())
+	assertNeverDispatched(t, counter)
+}


### PR DESCRIPTION
## Overview

`/v1/triggerAction` has no caller authentication, and its Service carries no NetworkPolicy — any pod on the cluster network can call it. Its shared dispatcher previously accepted every `CommandName` the operator recognizes, including `operatorAction` (the command type behind `annotate`/`quarantine`/`revert`/`patch`). That meant an anonymous caller with zero credentials could direct the operator's cluster-wide remediation RBAC at arbitrary workloads.

This closes that specific gap by allowlisting exactly the `CommandName`s the endpoint's real callers send, and rejecting everything else — including `operatorAction`.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

## Context

Found while validating a security finding on #410 (the new generic `patch` remediation action). I verified this live on `armo-dev-stage`: an anonymous, tokenless POST from a throwaway in-cluster pod to `operator:4002/v1/triggerAction` returned `200`/`ok` with no auth challenge at any layer.

I then confirmed exactly who the legitimate callers are and what they send, live:

| CronJob | `commandName` sent |
|---|---|
| `kubescape-scheduler` | `kubescapeScan` |
| `kubevuln-scheduler` | `scan` |
| registry-scan CronJob (created dynamically) | `scanRegistryV2` |

None of them ever send `operatorAction`. The backend's actual command channel is unrelated to this endpoint entirely — it goes through the `synchronizer` component's own authenticated outbound connection, which creates `OperatorCommand` CRs gated by real Kubernetes RBAC (`ClusterRole/synchronizer`). `/v1/triggerAction` is a separate, secondary HTTP door into the same dispatch code, with none of that path's guardrails.

## What's in this PR

- `restapihandler/triggeraction.go`: `triggerActionAllowedCommands` allowlist, checked per-command before dispatch (same rejection pattern already used for an empty `CommandName` — logged, recorded on status as a no-op, skipped; HTTP response stays `200`/`ok`, unchanged).
- `restapihandler/triggeraction_test.go`: covers an allowed command being dispatched, `operatorAction` (including the exact shape a `patch` action would need) being rejected, an unknown command being rejected, a mixed batch dispatching only the allowed entry, and the HTTP-level response shape for a rejected command.
- `docs/features/trigger-action-command-allowlist.md`: what changed and why.

## Follow-up

This is a stopgap, not a full fix — the endpoint is still unauthenticated for the commands it does allow. The real fix is to stop using an unauthenticated HTTP callback here at all and have these CronJobs create `OperatorCommand` CRs directly (the same authenticated/RBAC-gated mechanism `synchronizer` already uses), removing this HTTP path entirely. That requires Helm chart changes, so I'm opening a separate tracking issue for it rather than bundling it here.

## How to test

```
go build ./...
go vet ./...
go test ./restapihandler/... -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MmNHibtv3BGpGLqzWYgwQ

AI-skills: oh-my-claudecode:cancel | cmds: /oh-my-claudecode:autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted trigger-action requests to approved scan commands: `kubescapeScan`, `scan`, and `scanRegistryV2`.
  * Operator actions and unrecognized or empty commands are rejected before execution.
  * Rejected commands are recorded as errors while the endpoint continues returning a successful HTTP response.

* **Documentation**
  * Added guidance describing the trigger-action command allowlist and rejection behavior.

* **Tests**
  * Added coverage for approved, rejected, mixed, and empty command requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->