### PR TITLE
fix(continuousscanning): fail startup on invalid matching rules config

### DIFF
--- a/continuousscanning/loader.go
+++ b/continuousscanning/loader.go
@@ -1,8 +1,11 @@
 package continuousscanning
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -34,9 +37,11 @@ type targetLoader struct {
 	fetcher MatchingRuleFetcher
 }
 
+// TargetLoader loads matching-rule targets used to establish watches.
 type TargetLoader interface {
-	LoadGVRs(ctx context.Context) []schema.GroupVersionResource
-	LoadNamespaces(ctx context.Context) []string
+	// Load returns the GVRs to watch and the namespaces to restrict them to.
+	// An empty namespaces slice means every namespace.
+	Load(ctx context.Context) ([]schema.GroupVersionResource, []string, error)
 }
 
 // NewTargetLoader returns a new Target Loader
@@ -62,32 +67,22 @@ func matchRuleToGVR(apiMatch APIResourceMatch) []schema.GroupVersionResource {
 	return gvrs
 }
 
-// LoadGVRs loads GroupVersionResource definitions
-func (l *targetLoader) LoadGVRs(ctx context.Context) []schema.GroupVersionResource {
-	gvrs := []schema.GroupVersionResource{}
-
-	rules, _ := l.fetcher.Fetch(ctx)
-
-	apiResourceMatches := rules.APIResources
-	for idx := range apiResourceMatches {
-		ruleGvrs := matchRuleToGVR(apiResourceMatches[idx])
-		gvrs = append(gvrs, ruleGvrs...)
-	}
-
-	return gvrs
-}
-
-// LoadNamespaces loads the namespaces the matching rules restrict watches to.
-//
-// An empty result means every namespace, which is what a rule set that
-// omits the field asks for.
-func (l *targetLoader) LoadNamespaces(ctx context.Context) []string {
+// Load fetches matching rules once and returns the GVRs and namespaces to watch.
+func (l *targetLoader) Load(ctx context.Context) ([]schema.GroupVersionResource, []string, error) {
 	rules, err := l.fetcher.Fetch(ctx)
-	if err != nil || rules == nil {
-		return nil
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to fetch matching rules: %w", err)
+	}
+	if rules == nil {
+		return nil, nil, errors.New("matching rules are null")
 	}
 
-	return rules.Namespaces
+	gvrs := []schema.GroupVersionResource{}
+	for idx := range rules.APIResources {
+		gvrs = append(gvrs, matchRuleToGVR(rules.APIResources[idx])...)
+	}
+
+	return gvrs, rules.Namespaces, nil
 }
 
 type fileFetcher struct {
@@ -110,7 +105,17 @@ func parseMatchingRules(r io.Reader) (*MatchingRules, error) {
 		return nil, err
 	}
 
-	var matches *MatchingRules
-	err = json.Unmarshal(data, &matches)
-	return matches, err
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, errors.New("matching rules are empty")
+	}
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil, errors.New("matching rules are null")
+	}
+
+	var matches MatchingRules
+	if err := json.Unmarshal(trimmed, &matches); err != nil {
+		return nil, fmt.Errorf("failed to parse matching rules: %w", err)
+	}
+	return &matches, nil
 }

--- a/continuousscanning/loader_test.go
+++ b/continuousscanning/loader_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -41,7 +44,6 @@ func TestFileFetcher(t *testing.T) {
 }`
 	tt := []struct {
 		name            string
-		inputData       []byte
 		inputDataReader io.Reader
 		wantRules       *MatchingRules
 		wantError       bool
@@ -82,8 +84,7 @@ func TestFileFetcher(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			var f MatchingRuleFetcher
-			f = NewFileFetcher(tc.inputDataReader)
+			f := MatchingRuleFetcher(NewFileFetcher(tc.inputDataReader))
 
 			gotRules, gotError := f.Fetch(ctx)
 
@@ -95,24 +96,157 @@ func TestFileFetcher(t *testing.T) {
 	}
 }
 
+func TestParseMatchingRules(t *testing.T) {
+	chartDefault := `{
+	"match": [
+		{
+			"apiGroups": ["apps"],
+			"apiVersions": ["v1"],
+			"resources": ["deployments"]
+		}
+	],
+	"namespaces": ["default"]
+}`
+	tt := []struct {
+		name      string
+		input     string
+		wantError bool
+		wantRules *MatchingRules
+	}{
+		{
+			name:      "null",
+			input:     "null",
+			wantError: true,
+		},
+		{
+			name:      "whitespace plus null",
+			input:     "  null  ",
+			wantError: true,
+		},
+		{
+			name:      "malformed JSON",
+			input:     "{not json",
+			wantError: true,
+		},
+		{
+			name:      "empty file",
+			input:     "",
+			wantError: true,
+		},
+		{
+			name:      "whitespace-only file",
+			input:     "   \n\t  ",
+			wantError: true,
+		},
+		{
+			name:  "explicitly empty match",
+			input: `{"match":[]}`,
+			wantRules: &MatchingRules{
+				APIResources: []APIResourceMatch{},
+			},
+		},
+		{
+			name:  "chart default",
+			input: chartDefault,
+			wantRules: &MatchingRules{
+				APIResources: []APIResourceMatch{
+					{
+						Groups:    []string{"apps"},
+						Versions:  []string{"v1"},
+						Resources: []string{"deployments"},
+					},
+				},
+				Namespaces: []string{"default"},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseMatchingRules(strings.NewReader(tc.input))
+			if tc.wantError {
+				require.Error(t, err)
+				assert.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantRules, got)
+		})
+	}
+}
+
 type stubFetcher struct {
 	data *MatchingRules
+	err  error
 }
 
 func (f *stubFetcher) Fetch(ctx context.Context) (*MatchingRules, error) {
-	return f.data, nil
+	return f.data, f.err
 }
 
-func TestTargetLoader(t *testing.T) {
+type countingFetcher struct {
+	calls atomic.Int32
+	data  *MatchingRules
+	err   error
+}
+
+func (f *countingFetcher) Fetch(ctx context.Context) (*MatchingRules, error) {
+	f.calls.Add(1)
+	return f.data, f.err
+}
+
+func TestTargetLoaderLoad(t *testing.T) {
+	chartDefault := `{
+	"match": [
+		{
+			"apiGroups": ["apps"],
+			"apiVersions": ["v1"],
+			"resources": ["deployments"]
+		}
+	],
+	"namespaces": ["default", "kube-system"]
+}`
+
 	tt := []struct {
-		name               string
-		inputMatchingRules *MatchingRules
-		wantGVRs           []schema.GroupVersionResource
-		wantErr            bool
+		name           string
+		fetcher        MatchingRuleFetcher
+		wantGVRs       []schema.GroupVersionResource
+		wantNamespaces []string
+		wantErr        bool
+		errContains    string
 	}{
 		{
-			name: "single valid GVRs should return appropriate values",
-			inputMatchingRules: &MatchingRules{
+			name:    "null JSON",
+			fetcher: NewFileFetcher(strings.NewReader("null")),
+			wantErr: true,
+		},
+		{
+			name:    "malformed JSON",
+			fetcher: NewFileFetcher(strings.NewReader("{not json")),
+			wantErr: true,
+		},
+		{
+			name:    "empty file",
+			fetcher: NewFileFetcher(strings.NewReader("")),
+			wantErr: true,
+		},
+		{
+			name:           "explicitly empty match",
+			fetcher:        NewFileFetcher(strings.NewReader(`{"match":[]}`)),
+			wantGVRs:       []schema.GroupVersionResource{},
+			wantNamespaces: nil,
+		},
+		{
+			name:    "chart default with namespaces",
+			fetcher: NewFileFetcher(strings.NewReader(chartDefault)),
+			wantGVRs: []schema.GroupVersionResource{
+				{Group: "apps", Version: "v1", Resource: "deployments"},
+			},
+			wantNamespaces: []string{"default", "kube-system"},
+		},
+		{
+			name: "single valid GVRs",
+			fetcher: &stubFetcher{data: &MatchingRules{
 				APIResources: []APIResourceMatch{
 					{
 						Groups:    []string{""},
@@ -120,37 +254,15 @@ func TestTargetLoader(t *testing.T) {
 						Resources: []string{"Pod", "ReplicaSet"},
 					},
 				},
-			},
+			}},
 			wantGVRs: []schema.GroupVersionResource{
 				{Group: "", Version: "v1", Resource: "Pod"},
 				{Group: "", Version: "v1", Resource: "ReplicaSet"},
 			},
 		},
 		{
-			name: "single valid GVRs should return appropriate values",
-			inputMatchingRules: &MatchingRules{
-				APIResources: []APIResourceMatch{
-					{
-						Groups:    []string{""},
-						Versions:  []string{"v1"},
-						Resources: []string{"Pod", "ReplicaSet"},
-					},
-					{
-						Groups:    []string{"rbac.authorization.k8s.io"},
-						Versions:  []string{"v1"},
-						Resources: []string{"ClusterRoleBinding"},
-					},
-				},
-			},
-			wantGVRs: []schema.GroupVersionResource{
-				{Group: "", Version: "v1", Resource: "Pod"},
-				{Group: "", Version: "v1", Resource: "ReplicaSet"},
-				{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "ClusterRoleBinding"},
-			},
-		},
-		{
-			name: "multiple valid GVRs should return appropriate values",
-			inputMatchingRules: &MatchingRules{
+			name: "multiple groups and versions",
+			fetcher: &stubFetcher{data: &MatchingRules{
 				APIResources: []APIResourceMatch{
 					{
 						Groups:    []string{""},
@@ -163,7 +275,7 @@ func TestTargetLoader(t *testing.T) {
 						Resources: []string{"ClusterRoleBinding"},
 					},
 				},
-			},
+			}},
 			wantGVRs: []schema.GroupVersionResource{
 				{Group: "", Version: "v1", Resource: "Pod"},
 				{Group: "", Version: "v1", Resource: "ReplicaSet"},
@@ -172,33 +284,21 @@ func TestTargetLoader(t *testing.T) {
 				{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "ClusterRoleBinding"},
 			},
 		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			var fetcher MatchingRuleFetcher
-			fetcher = &stubFetcher{tc.inputMatchingRules}
-			var l TargetLoader
-			l = NewTargetLoader(fetcher)
-
-			gotData := l.LoadGVRs(ctx)
-
-			assert.Equal(t, tc.wantGVRs, gotData)
-		})
-	}
-
-}
-
-func TestTargetLoaderLoadNamespaces(t *testing.T) {
-	tt := []struct {
-		name               string
-		inputMatchingRules *MatchingRules
-		wantNamespaces     []string
-	}{
 		{
-			name: "the configured namespaces are returned",
-			inputMatchingRules: &MatchingRules{
+			name:        "fetcher returns nil nil",
+			fetcher:     &stubFetcher{data: nil, err: nil},
+			wantErr:     true,
+			errContains: "matching rules are null",
+		},
+		{
+			name:        "fetcher returns error",
+			fetcher:     &stubFetcher{data: nil, err: errors.New("boom")},
+			wantErr:     true,
+			errContains: "boom",
+		},
+		{
+			name: "configured namespaces are returned",
+			fetcher: &stubFetcher{data: &MatchingRules{
 				APIResources: []APIResourceMatch{
 					{
 						Groups:    []string{"apps"},
@@ -207,12 +307,15 @@ func TestTargetLoaderLoadNamespaces(t *testing.T) {
 					},
 				},
 				Namespaces: []string{"default", "kube-system"},
+			}},
+			wantGVRs: []schema.GroupVersionResource{
+				{Group: "apps", Version: "v1", Resource: "deployments"},
 			},
 			wantNamespaces: []string{"default", "kube-system"},
 		},
 		{
 			name: "no namespaces means every namespace",
-			inputMatchingRules: &MatchingRules{
+			fetcher: &stubFetcher{data: &MatchingRules{
 				APIResources: []APIResourceMatch{
 					{
 						Groups:    []string{"apps"},
@@ -220,6 +323,9 @@ func TestTargetLoaderLoadNamespaces(t *testing.T) {
 						Resources: []string{"deployments"},
 					},
 				},
+			}},
+			wantGVRs: []schema.GroupVersionResource{
+				{Group: "apps", Version: "v1", Resource: "deployments"},
 			},
 			wantNamespaces: nil,
 		},
@@ -227,10 +333,46 @@ func TestTargetLoaderLoadNamespaces(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			l := NewTargetLoader(&stubFetcher{tc.inputMatchingRules})
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Load panicked: %v", r)
+				}
+			}()
 
-			assert.Equal(t, tc.wantNamespaces, l.LoadNamespaces(ctx))
+			ctx := context.Background()
+			l := NewTargetLoader(tc.fetcher)
+
+			gotGVRs, gotNamespaces, err := l.Load(ctx)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.errContains != "" {
+					assert.ErrorContains(t, err, tc.errContains)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantGVRs, gotGVRs)
+			assert.Equal(t, tc.wantNamespaces, gotNamespaces)
 		})
 	}
+}
+
+func TestTargetLoaderLoad_SingleFetch(t *testing.T) {
+	fetcher := &countingFetcher{
+		data: &MatchingRules{
+			APIResources: []APIResourceMatch{
+				{
+					Groups:    []string{"apps"},
+					Versions:  []string{"v1"},
+					Resources: []string{"deployments"},
+				},
+			},
+			Namespaces: []string{"default"},
+		},
+	}
+	l := NewTargetLoader(fetcher)
+
+	_, _, err := l.Load(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), fetcher.calls.Load())
 }

--- a/continuousscanning/service.go
+++ b/continuousscanning/service.go
@@ -2,8 +2,8 @@ package continuousscanning
 
 import (
 	"context"
+	"fmt"
 
-	armoapi "github.com/armosec/armoapi-go/apis"
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/operator/config"
@@ -23,16 +23,19 @@ type ContinuousScanningService struct {
 	eventQueue        *watcher.CooldownQueue
 }
 
-func (s *ContinuousScanningService) listen(ctx context.Context) <-chan armoapi.Command {
-	producedCommands := make(chan armoapi.Command)
-
+func (s *ContinuousScanningService) listen(ctx context.Context) error {
 	listOpts := metav1.ListOptions{}
 	resourceEventsCh := make(chan watch.Event, 100)
 
-	gvrs := s.tl.LoadGVRs(ctx)
-	namespaces := s.tl.LoadNamespaces(ctx)
+	gvrs, namespaces, err := s.tl.Load(ctx)
+	if err != nil {
+		return err
+	}
 	logger.L().Info("fetched gvrs", helpers.Interface("gvrs", gvrs), helpers.Interface("namespaces", namespaces))
-	wp, _ := NewWatchPool(ctx, s.k8sdynamic, gvrs, namespaces, listOpts)
+	wp, err := NewWatchPool(ctx, s.k8sdynamic, gvrs, namespaces, listOpts)
+	if err != nil {
+		return fmt.Errorf("failed to create watch pool: %w", err)
+	}
 	wp.Run(ctx, resourceEventsCh)
 	logger.L().Info("ran watch pool")
 
@@ -57,7 +60,7 @@ func (s *ContinuousScanningService) listen(ctx context.Context) <-chan armoapi.C
 
 	}(s.shutdownRequested, resourceEventsCh, s.eventQueue)
 
-	return producedCommands
+	return nil
 }
 
 func (s *ContinuousScanningService) work(ctx context.Context) {
@@ -87,13 +90,12 @@ func (s *ContinuousScanningService) work(ctx context.Context) {
 // It sets up the provided watches, listens for events they deliver in the
 // background and dispatches them to registered event handlers.
 // Launch blocks until all the underlying watches are ready to accept events.
-func (s *ContinuousScanningService) Launch(ctx context.Context) <-chan armoapi.Command {
-	out := make(chan armoapi.Command)
-
-	s.listen(ctx)
+func (s *ContinuousScanningService) Launch(ctx context.Context) error {
+	if err := s.listen(ctx); err != nil {
+		return err
+	}
 	go s.work(ctx)
-
-	return out
+	return nil
 }
 
 func (s *ContinuousScanningService) AddEventHandler(fn EventHandler) {

--- a/continuousscanning/service_test.go
+++ b/continuousscanning/service_test.go
@@ -2,6 +2,7 @@ package continuousscanning
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/kubescape/operator/utils"
 	"github.com/panjf2000/ants/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -153,7 +155,7 @@ func TestAddEventHandler(t *testing.T) {
 			spyH := &spyHandler{called: false, wg: resourcesCreatedWg, mx: &sync.RWMutex{}}
 			operatorConfig := config.NewOperatorConfig(config.CapabilitiesConfig{}, utilsmetadata.ClusterConfig{}, &beUtils.Credentials{}, config.Config{Namespace: "kubescape"})
 			css := NewContinuousScanningService(operatorConfig, dynClient, tl, spyH)
-			css.Launch(ctx)
+			require.NoError(t, css.Launch(ctx))
 
 			// Create Pods to be listened
 			podsGvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "Pods"}
@@ -263,10 +265,10 @@ func TestContinuousScanningService(t *testing.T) {
 			wp, _ := ants.NewPoolWithFunc(1, processingFunc)
 			operatorConfig := config.NewOperatorConfig(config.CapabilitiesConfig{}, utilsmetadata.ClusterConfig{ClusterName: clusterNameStub}, &beUtils.Credentials{}, config.Config{})
 			triggeringHandler := NewTriggeringHandler(wp, operatorConfig)
-			stubFetcher := &stubFetcher{podMatchRules}
+			stubFetcher := &stubFetcher{data: podMatchRules}
 			loader := NewTargetLoader(stubFetcher)
 			css := NewContinuousScanningService(operatorConfig, dynClient, loader, triggeringHandler)
-			css.Launch(ctx)
+			require.NoError(t, css.Launch(ctx))
 
 			// Create Pods to be listened
 			createOpts := metav1.CreateOptions{}
@@ -284,6 +286,36 @@ func TestContinuousScanningService(t *testing.T) {
 			css.Stop()
 
 			assert.ElementsMatch(t, tc.want, gotCommands.Commands())
+		})
+	}
+}
+
+func TestLaunch_InvalidMatchingRules(t *testing.T) {
+	tt := []struct {
+		name  string
+		input string
+	}{
+		{name: "null", input: "null"},
+		{name: "malformed JSON", input: "{not json"},
+		{name: "empty file", input: ""},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("Launch panicked: %v", r)
+				}
+			}()
+
+			ctx := context.Background()
+			dynClient := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+			loader := NewTargetLoader(NewFileFetcher(strings.NewReader(tc.input)))
+			operatorConfig := config.NewOperatorConfig(config.CapabilitiesConfig{}, utilsmetadata.ClusterConfig{}, &beUtils.Credentials{}, config.Config{Namespace: "kubescape"})
+			css := NewContinuousScanningService(operatorConfig, dynClient, loader)
+
+			err := css.Launch(ctx)
+			require.Error(t, err)
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -167,10 +167,10 @@ func main() {
 	if operatorConfig.ContinuousScanEnabled() {
 		go func(mh *mainhandler.MainHandler) {
 			err := mh.SetupContinuousScanning(ctx)
-			logger.L().Info("set up cont scanning service")
 			if err != nil {
 				logger.L().Ctx(ctx).Fatal(err.Error(), helpers.Error(err))
 			}
+			logger.L().Info("set up cont scanning service")
 		}(mainHandler)
 	}
 

--- a/main.go
+++ b/main.go
@@ -158,20 +158,24 @@ func main() {
 		go mainHandler.StartupTriggerActions(ctx, mainhandler.GetStartupActions(operatorConfig))
 	}
 
-	isReadinessReady = true
+	// When continuous scanning is disabled, publish readiness now. When it is
+	// enabled, delay readiness until SetupContinuousScanning succeeds so a pod
+	// with invalid matching rules cannot report ready while terminating.
+	if !operatorConfig.ContinuousScanEnabled() {
+		isReadinessReady = true
+	}
 
 	// wait for requests to come from the websocket or from the REST API
 	go mainHandler.HandleCommandResponse(ctx)
 	mainHandler.HandleWatchers(ctx)
 
 	if operatorConfig.ContinuousScanEnabled() {
-		go func(mh *mainhandler.MainHandler) {
-			err := mh.SetupContinuousScanning(ctx)
-			if err != nil {
-				logger.L().Ctx(ctx).Fatal(err.Error(), helpers.Error(err))
-			}
-			logger.L().Info("set up cont scanning service")
-		}(mainHandler)
+		err := mainHandler.SetupContinuousScanning(ctx)
+		if err != nil {
+			logger.L().Ctx(ctx).Fatal(err.Error(), helpers.Error(err))
+		}
+		logger.L().Info("set up cont scanning service")
+		isReadinessReady = true
 	}
 
 	// Start node agent autoscaler if enabled

--- a/mainhandler/handlerequests.go
+++ b/mainhandler/handlerequests.go
@@ -123,13 +123,16 @@ func (mainHandler *MainHandler) SetupContinuousScanning(ctx context.Context) err
 	if err != nil {
 		return err
 	}
+	defer rulesReader.Close()
 
 	fetcher := cs.NewFileFetcher(rulesReader)
 	loader := cs.NewTargetLoader(fetcher)
 
 	dynClient := mainHandler.k8sAPI.DynamicClient
 	svc := cs.NewContinuousScanningService(mainHandler.config, dynClient, loader, triggeringHandler, deletingHandler)
-	svc.Launch(ctx)
+	if err := svc.Launch(ctx); err != nil {
+		return fmt.Errorf("failed to load matching rules from %q: %w", rulesFilename, err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Harden parseMatchingRules and consolidate TargetLoader to a single Load() that fetches once. Propagate errors through listen/Launch when cs-matching-rules contains null, malformed, or empty JSON instead of panicking. Include the matching-rules filename in the setup error. Close the rules file after open and log success only after SetupContinuousScanning succeeds.

Fixes #399

## Overview
This PR fixes #399.

Previously, if the `cs-matching-rules` ConfigMap contained `null`, malformed JSON, or empty content, `LoadGVRs()` discarded the fetch error and dereferenced a nil `*MatchingRules`, panicking in a background goroutine and taking down the whole operator.

Now bad matching-rules input returns a clear configuration error (including the filename) and fails continuous-scanning setup fatally, instead of panicking. Valid `{"match":[]}` still works as a legitimate "watch nothing" config. `TargetLoader` is consolidated to a single `Load()` so the one-shot file reader is only fetched once.

**[Signed Commits](../CONTRIBUTING.md#sign-off-per-commit)**
- [x] Yes, I signed my commits.

## How to Test

```bash
go test ./continuousscanning/... -count=1 -v
go test -race ./continuousscanning/... -count=1
go test ./... -count=1
go build ./...
```

Confirm these cases:
- `"null"`, whitespace+`null`, malformed JSON, empty/whitespace-only → error, no panic
- `{"match":[]}` → success, 0 GVRs
- chart-default config → expected GVRs + namespaces
- fetcher `(nil, nil)` / fetch error → propagated error
- `Load()` fetches exactly once
- `Launch()` with invalid config → error, no panic (`TestLaunch_InvalidMatchingRules`)

## Related issues/PRs

* Fixes #399

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.
- [x] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**
```

Open against **`main`**, and keep the DCO box checked only if the commit was created with `git commit -s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Continuous scanning now reports setup and launch failures instead of silently continuing.
  - Invalid, empty, or null matching-rules files now produce clear errors rather than unexpected failures.
  - Configuration loading errors are propagated and associated with the relevant rules file.
  - Readiness is reported only after continuous scanning setup completes successfully.
  - Matching resources and namespaces are loaded consistently in a single operation.
  - Configuration data is fetched once per loading operation for more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->